### PR TITLE
Add word of the day for January 20, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-01-20.json
+++ b/data/dicolink_word_of_the_day_2025-01-20.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "Goguenard",
+    "date": "January 20, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui manifeste une raillerie contenue, une certaine insolence narquoise ; moqueur : Regarder quelqu'un d'un air goguenard."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui affecte la moquerie, la raillerie.",
+                "n.  Moqueur, railleur."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the word of the day for **January 20, 2025**.