### PR TITLE
Add word of the day for January 25, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-01-25.json
+++ b/data/dicolink_word_of_the_day_2025-01-25.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Incurieux",
+    "date": "January 25, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Qui n'a pas de curiosité."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui ne se soucie pas de."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Qui ne se soucie pas de. Un esprit incurieux. Incurieux d'accroître sa fortune."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **January 25, 2025**.