### PR TITLE
Add word of the day for January 26, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-01-26.json
+++ b/data/dicolink_word_of_the_day_2025-01-26.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Articulet",
+    "date": "January 26, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Petit article, dans un journal, une publication."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Petit article paru dans la presse."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Petit article paru dans la presse."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **January 26, 2025**.