### PR TITLE
Add word of the day for January 27, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-01-27.json
+++ b/data/dicolink_word_of_the_day_2025-01-27.json
@@ -1,0 +1,32 @@
+{
+    "word_of_the_day": "Camard",
+    "date": "January 27, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Vieux. Qui a un nez plat et écrasé ; se dit du nez lui-même."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui a le nez plat et écrasé.",
+                "(Par extension) Qualifie aussi le nez lui-même.",
+                "n.  Il s’emploie encore comme nom.",
+                "n.  (Figuré) La mort."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui a le nez plat et écrasé.",
+                "(Par extension) Qualifie aussi le nez lui-même.",
+                "(Serrurerie) Qualifie un pêne de serrure taillé en biseau et par extension la serrure elle même.",
+                "Personne camarde.",
+                "(Technique) En papeterie, désigne une coupe en diagonale dans un coin d’une feuille. Ce camard sert ensuite — par exemple pour un imprimeur — à orienter la feuille."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **January 27, 2025**.