### PR TITLE
Add word of the day for January 28, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-01-28.json
+++ b/data/dicolink_word_of_the_day_2025-01-28.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "Pétré",
+    "date": "January 28, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "Couvert de pierres."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Didactique) (Extrêmement rare) Qui est pierreux, rocheux.",
+                "(Exclusivement) Qualifie la partie de l’Arabie qui est couverte de pierres, de rochers."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **January 28, 2025**.