### PR TITLE
Add word of the day for January 29, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-01-29.json
+++ b/data/dicolink_word_of_the_day_2025-01-29.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Affable",
+    "date": "January 29, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui accueille aimablement les gens : Un sourire affable."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Personne aimable et bienveillante à qui on peut parler (qui écoute et comprend)."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Personne aimable et bienveillante à qui on peut parler (qui écoute et comprend)."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **January 29, 2025**.