### PR TITLE
Add word of the day for January 30, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-01-30.json
+++ b/data/dicolink_word_of_the_day_2025-01-30.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Boqueteau",
+    "date": "January 30, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Petit bois, bouquet d'arbres, le plus souvent au milieu d'une plaine."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Petit bois, groupe d’arbres."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Petit bois, groupe d’arbres."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **January 30, 2025**.