### PR TITLE
Add word of the day for February 07, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-02-07.json
+++ b/data/dicolink_word_of_the_day_2025-02-07.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Harpagon",
+    "date": "February 07, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Littéraire. Homme d'une grande avarice."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Avare."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Avare."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **February 07, 2025**.