### PR TITLE
Add word of the day for February 09, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-02-09.json
+++ b/data/dicolink_word_of_the_day_2025-02-09.json
@@ -1,0 +1,32 @@
+{
+    "word_of_the_day": "Délassant",
+    "date": "February 09, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui délasse physiquement ou intellectuellement ; reposant, détendant : Une lecture délassante."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui délasse."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Qui délasse. C'est un exercice délassant."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui délasse.",
+                "Participe présent de délasser."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **February 09, 2025**.