### PR TITLE
Add word of the day for February 11, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-02-11.json
+++ b/data/dicolink_word_of_the_day_2025-02-11.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Matutinal",
+    "date": "February 11, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Qui appartient au matin."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Littéraire) Matinal."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Qui appartient au matin. Peu usité."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **February 11, 2025**.