### PR TITLE
Add Robert word of the day for February 14, 2025

### DIFF
--- a/data/robert_word_of_the_day_2025-02-14.json
+++ b/data/robert_word_of_the_day_2025-02-14.json
@@ -1,0 +1,8 @@
+{
+    "word_of_the_day": "Suggestions proposées pour\n\t\tmot-du-jour",
+    "date": "February 14, 2025",
+    "source_url": "https://dictionnaire.lerobert.com/mot-du-jour",
+    "definitions": [
+        "modulor"
+    ]
+}


### PR DESCRIPTION
Automatically added the Robert word of the day for **February 14, 2025**.