### PR TITLE
Add word of the day for February 19, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-02-19.json
+++ b/data/dicolink_word_of_the_day_2025-02-19.json
@@ -1,0 +1,21 @@
+{
+    "word_of_the_day": "Turpitude",
+    "date": "February 19, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Laideur morale, ignominie qui résulte d'un comportement honteux.",
+                "n.f. Action, parole, pensée honteuse, infamie."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Ignominie qui résulte de quelque action honteuse.",
+                "n.  Ensemble d'actions honteuses, d'écrits ou de paroles ignobles."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **February 19, 2025**.