### PR TITLE
Add word of the day for February 20, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-02-20.json
+++ b/data/dicolink_word_of_the_day_2025-02-20.json
@@ -1,0 +1,21 @@
+{
+    "word_of_the_day": "Hellénisant",
+    "date": "February 20, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj.n. Qui étudie la langue, la littérature et la civilisation grecques."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Celui, celle qui s’occupe des études grecques.",
+                "n.  Personne qui parle grec (sans être grecque), qui est marquée par l’hellénisme.",
+                "Parlant grec, marqué par l’hellénisme."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **February 20, 2025**.