### PR TITLE
Add word of the day for February 26, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-02-26.json
+++ b/data/dicolink_word_of_the_day_2025-02-26.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Lapidifier",
+    "date": "February 26, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Convertir en pierre, donner à une substance la dureté de la pierre."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Devenir de consistance pierreuse, en parlant d’une masse minérale."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **February 26, 2025**.