### PR TITLE
Add word of the day for February 27, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-02-27.json
+++ b/data/dicolink_word_of_the_day_2025-02-27.json
@@ -1,0 +1,35 @@
+{
+    "word_of_the_day": "Colliger",
+    "date": "February 27, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Réunir des textes, des notes pour constituer un tout (recueil, synthèse, etc.).",
+                "v. tr. Relier plusieurs observations en une notion synthétique permettant d'induire un phénomène non encore détecté."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Réunir des éléments, des extraits de documents dans le but de réaliser une anthologie, une synthèse.",
+                "v.  Recueillir, rassembler des éléments de même nature."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1: Faire des collections de pierres, d'insectes, etc.",
+                "Sens 2: Faire des extraits. Vieux en ce sens."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Réunir des éléments, des extraits de documents dans le but de réaliser une anthologie, une synthèse.",
+                "Recueillir ou rassembler des éléments de même nature."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **February 27, 2025**.