### PR TITLE
Add word of the day for March 02, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-03-02.json
+++ b/data/dicolink_word_of_the_day_2025-03-02.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Pétaudière",
+    "date": "March 02, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Familier. Assemblée, organisme où règnent la confusion et l'anarchie."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Assemblée où il n’y a pas d’ordre, lieu où chacun veut commander. ? voir anomie, confusion et désordre"
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Assemblée confuse, où chacun fait le maître."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **March 02, 2025**.