### PR TITLE
Add word of the day for March 04, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-03-04.json
+++ b/data/dicolink_word_of_the_day_2025-03-04.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Hâbleur",
+    "date": "March 04, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj.n. Qui a l'habitude de parler beaucoup et de se vanter, qui cherche à donner une haute idée de sa personne."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Péjoratif) Qui hâble, qui parle avec exagération, emphase et vantardise.",
+                "n.  (Péjoratif) Substantif de l’adjectif : personne qui hâble, qui parle avec exagération, emphase et vantardise."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Péjoratif) Qui hâble, qui parle avec exagération, emphase et vantardise.",
+                "(Péjoratif) Personne qui hâble, qui parle avec exagération, emphase et vantardise."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **March 04, 2025**.