### PR TITLE
Add word of the day for March 08, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-03-08.json
+++ b/data/dicolink_word_of_the_day_2025-03-08.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Mirliflore",
+    "date": "March 08, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Vieux. Jeune élégant satisfait de sa personne."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Familier) Jeune homme qui se pique d’élégance, qui fait l’agréable, qui cherche à briller."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **March 08, 2025**.