### PR TITLE
Add word of the day for March 12, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-03-12.json
+++ b/data/dicolink_word_of_the_day_2025-03-12.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "Stipendié",
+    "date": "March 12, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj.n. Se dit de quelqu'un qui est payé, corrompu ; mercenaire."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Péjoratif) Qui reçoit une solde pour agir.",
+                "n.  Celui, celle qui est à la solde et agit pour le compte d'un autre ou d'une organisation."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **March 12, 2025**.