### PR TITLE
Add word of the day for March 16, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-03-16.json
+++ b/data/dicolink_word_of_the_day_2025-03-16.json
@@ -1,0 +1,26 @@
+{
+    "word_of_the_day": "Nival",
+    "date": "March 16, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Relatif à la neige.",
+                "adj. Se dit d'un régime fluvial caractérisé par des crues printanières dues à la fonte des neiges."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "De la neige ; qui est dû à la neige."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "De la neige ; qui est dû à la neige."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **March 16, 2025**.