### PR TITLE
Add word of the day for March 17, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-03-17.json
+++ b/data/dicolink_word_of_the_day_2025-03-17.json
@@ -1,0 +1,31 @@
+{
+    "word_of_the_day": "Maugréer",
+    "date": "March 17, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Manifester contre quelqu'un, contre quelque chose sa mauvaise humeur."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Manifester une très mauvaise humeur, en parlant ou plus souvent en grommelant."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Témoigner son mauvais gré, son mécontentement en pestant, jurant. Nous maugréions contre la pluie qui nous empêchait de sortir.Activement."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Manifester une très mauvaise humeur, en parlant ou plus souvent en grommelant."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **March 17, 2025**.