### PR TITLE
Add word of the day for March 26, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-03-26.json
+++ b/data/dicolink_word_of_the_day_2025-03-26.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Emacie",
+    "date": "March 26, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Amaigrir, rendre maigre : La fatigue a émacié ses joues."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui est très amaigri."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **March 26, 2025**.