### PR TITLE
Add word of the day for March 27, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-03-27.json
+++ b/data/dicolink_word_of_the_day_2025-03-27.json
@@ -1,0 +1,26 @@
+{
+    "word_of_the_day": "Disert",
+    "date": "March 27, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Qui s'exprime, parle facilement et avec agrément, éloquent ; qui manifeste cette aptitude."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Se dit de quelqu’un qui a de l’aisance à parler."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Se dit de quelqu’un qui a de l’aisance à parler.",
+                "(Figuré) Qui apporte beaucoup d’informations."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **March 27, 2025**.