### PR TITLE
Add word of the day for March 28, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-03-28.json
+++ b/data/dicolink_word_of_the_day_2025-03-28.json
@@ -1,0 +1,36 @@
+{
+    "word_of_the_day": "Guéret",
+    "date": "March 28, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Terre qui a été labourée en attendant les semailles d'automne.",
+                "n.m. Dans un champ en cours de labour, partie non encore labourée."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Terre labourée et non ensemencée, ou même terre laissée en jachère.",
+                "n.  (Poésie) (Au pluriel) Toutes les terres propres à porter des grains, qu’elles soient ensemencées ou qu’elles ne le soient pas."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1: Terre labourée et non ensemencée.   Lever ou relever les guérets, labourer une terre qu'on a laissée se reposer pendant un an.",
+                "Sens 2: En langage agricole, ancien guéret, la partie non labourée d'un champ qu'on est en train de labourer. Ainsi, la charrue versant à droite, le laboureur a l'ancien guéret à sa gauche, la gauche est le côté de l'ancien guéret.",
+                "Sens 3:  Poétiquement. Toutes terres labourables."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Terre labourée et non ensemencée, ou même terre laissée en jachère.",
+                "(Au pluriel) (Poésie) Toutes les terres propres à porter des grains, qu’elles soient ensemencées ou qu’elles ne le soient pas."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **March 28, 2025**.