### PR TITLE
Add word of the day for March 29, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-03-29.json
+++ b/data/dicolink_word_of_the_day_2025-03-29.json
@@ -1,0 +1,38 @@
+{
+    "word_of_the_day": "Tudesque",
+    "date": "March 29, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Vieux. Qui se rapporte aux Allemands."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Histoire) Qui est relatif aux anciens Germains.",
+                "(Vieilli) Germanique, allemand ancien.",
+                "(Péjoratif) Par dénigrement, qualifie des expressions, un comportement, des manières grossières.",
+                "n.  Ancienne langue germanique."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Sens 1: Qui appartient aux anciens Germains. La langue tudesque. S. m.:  Le tudesque, la langue des anciens Germains. Il s'est dit quelquefois pour Allemand.",
+                "adj. Sens 2:  Par dénigrement, qui a quelque chose de rude, de grossier, sans élégance."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Histoire) Relatif aux anciens Germains.",
+                "(Vieilli) Germanique ; allemand ancien.",
+                "(Péjoratif) Par dénigrement, qualifie des expressions, un comportement, des manières grossières.",
+                "Ancienne langue germanique."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **March 29, 2025**.