### PR TITLE
Add word of the day for April 11, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-04-11.json
+++ b/data/dicolink_word_of_the_day_2025-04-11.json
@@ -1,0 +1,13 @@
+{
+    "word_of_the_day": "Uligineux",
+    "date": "April 11, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Vieilli) Humide ; marécageux."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 11, 2025**.