### PR TITLE
Add Robert word of the day for April 13, 2025

### DIFF
--- a/data/robert_word_of_the_day_2025-04-13.json
+++ b/data/robert_word_of_the_day_2025-04-13.json
@@ -1,0 +1,8 @@
+{
+    "word_of_the_day": "Suggestions proposées pour\n\t\tmot-du-jour",
+    "date": "April 13, 2025",
+    "source_url": "https://dictionnaire.lerobert.com/mot-du-jour",
+    "definitions": [
+        "modulor"
+    ]
+}


### PR DESCRIPTION
Automatically added the Robert word of the day for **April 13, 2025**.