### PR TITLE
Add word of the day for April 15, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-04-15.json
+++ b/data/dicolink_word_of_the_day_2025-04-15.json
@@ -1,0 +1,31 @@
+{
+    "word_of_the_day": "Amphitryon",
+    "date": "April 15, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Littéraire. Personne chez qui ou aux frais de qui on dîne."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Soutenu) Hôte chez qui l’on est invité à manger."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Celui chez lequel, ou aux frais duquel on dîne."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Soutenu) Hôte chez qui l’on est invité à manger."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 15, 2025**.