### PR TITLE
Add word of the day for April 18, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-04-18.json
+++ b/data/dicolink_word_of_the_day_2025-04-18.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Impécunieux",
+    "date": "April 18, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Qui a peu d'argent."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui est sans argent."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj.  Terme vieilli. Qui n'est pas pourvu d'argent."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 18, 2025**.