### PR TITLE
Add word of the day for April 20, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-04-20.json
+++ b/data/dicolink_word_of_the_day_2025-04-20.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Improuver",
+    "date": "April 20, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  (Désuet) Ne pas approuver, blâmer."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "v. tr. Ne pas approuver, blâmer."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 20, 2025**.