### PR TITLE
Add word of the day for April 25, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-04-25.json
+++ b/data/dicolink_word_of_the_day_2025-04-25.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Emberlificoter",
+    "date": "April 25, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Familier. Embrouiller quelqu'un en l'enjôlant pour l'amener à ses propres vues : Emberlificoter un ami dans des discours flatteurs."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  (Familier) Embrouiller, embarrasser."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 25, 2025**.