### PR TITLE
Add word of the day for April 28, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-04-28.json
+++ b/data/dicolink_word_of_the_day_2025-04-28.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Anxiogène",
+    "date": "April 28, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Se dit d'une situation ou d'un objet susceptible de mobiliser de l'angoisse (ou de l'anxiété) chez un sujet."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui suscite l’anxiété, l’angoisse, l’inquiétude."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui suscite l’anxiété, l’angoisse, l’inquiétude."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 28, 2025**.