### PR TITLE
Add word of the day for April 30, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-04-30.json
+++ b/data/dicolink_word_of_the_day_2025-04-30.json
@@ -1,0 +1,26 @@
+{
+    "word_of_the_day": "Fallacieux",
+    "date": "April 30, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Qui cherche à tromper, à nuire ; perfide : Arguments fallacieux."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui est basé sur un mensonge ou un faux.",
+                "Qui vise à tromper."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Qui trompe et égare pour nuire. Il se dit aussi des choses."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 30, 2025**.