### PR TITLE
Add word of the day for May 19, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-05-19.json
+++ b/data/dicolink_word_of_the_day_2025-05-19.json
@@ -1,0 +1,13 @@
+{
+    "word_of_the_day": "Flagorner",
+    "date": "May 19, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Flatter grossièrement."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 19, 2025**.