### PR TITLE
Add word of the day for June 11, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-06-11.json
+++ b/data/dicolink_word_of_the_day_2025-06-11.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Clepsydre",
+    "date": "June 11, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Horloge à eau utilisée dans l'Antiquité. (L'eau remplissait une cuve munie à l'intérieur d'une échelle horaire et s'écoulait par un orifice ménagé à la base du récipient.)"
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Horlogerie) Horloge qui indique la marche du temps par l’écoulement d’une certaine quantité d’eau."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Horlogerie) Horloge qui indique la marche du temps par l’écoulement d’une certaine quantité d’eau."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 11, 2025**.