### PR TITLE
Add word of the day for June 12, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-06-12.json
+++ b/data/dicolink_word_of_the_day_2025-06-12.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Controuvé",
+    "date": "June 12, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Inventé de toutes pièces, mensonger : Anecdote controuvée."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Participe passé masculin singulier du verbe controuver."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 12, 2025**.