### PR TITLE
Add word of the day for June 16, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-06-16.json
+++ b/data/dicolink_word_of_the_day_2025-06-16.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Thuriféraire",
+    "date": "June 16, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Ministre servant, clerc ou laïque, qui porte l'encens et l'encensoir dans la liturgie romaine.",
+                "n.m. Littéraire. Personne qui loue, vante quelqu'un, quelque chose avec excès : Les thuriféraires du pouvoir."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Liturgie) Clerc qui, dans les cérémonies de l’église, a la fonction de porter l’encensoir. Il est accompagné par le naviculaire qui, lui, porte la navette (contenant l'encens).",
+                "n.  (Figuré) (Ironique) Flatteur, flagorneur."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Clerc qui dans les cérémonies de l'Église porte l'encensoir et la navette où est l'encens. Fig. Néologisme. Flatteur, louangeur."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 16, 2025**.