### PR TITLE
Add word of the day for June 17, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-06-17.json
+++ b/data/dicolink_word_of_the_day_2025-06-17.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "Grandiloquent",
+    "date": "June 17, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui a un caractère affecté, déclamatoire, pompeux, emphatique, ou de quelqu'un qui s'exprime de cette manière."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui s’exprime avec grandiloquence.",
+                "Où il y a de la grandiloquence."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 17, 2025**.