### PR TITLE
Add word of the day for June 18, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-06-18.json
+++ b/data/dicolink_word_of_the_day_2025-06-18.json
@@ -1,0 +1,34 @@
+{
+    "word_of_the_day": "Encan",
+    "date": "June 18, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Vente à l'encan, synonyme de vente aux enchères.",
+                "n.m. Littéraire. Être à l'encan, être livré au plus offrant.",
+                "n.m. Mettre quelque chose à l'encan, en faire un trafic honteux."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Vente publique à l’enchère, au plus offrant et dernier enchérisseur."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1: Vente publique à l'enchère.Vendre à l'encan. Mettre à l'encan.",
+                "Sens 2:  Fig."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Vente publique à l’enchère, au plus offrant et dernier enchérisseur."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 18, 2025**.