### PR TITLE
Add word of the day for June 20, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-06-20.json
+++ b/data/dicolink_word_of_the_day_2025-06-20.json
@@ -1,0 +1,38 @@
+{
+    "word_of_the_day": "Bourru",
+    "date": "June 20, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Se dit d'un vin en fin de fermentation, encore chargé en gaz carbonique et non clarifié.",
+                "adj.n. D'humeur brusque et acariâtre.",
+                "adj. Qui dénote un caractère brusque et bougon : Des manières bourrues."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui est d’une humeur brusque, fâchée et chagrine.",
+                "(Vieilli) (Propre) Qui est rempli de bourre, qui n’est pas lisse.",
+                "(Vieilli) Mal dégrossie, en parlant d’une pierre de construction.",
+                "Qui n’a pas totalement fermenté et qui se conserve doux dans le tonneau durant une semaine, en parlant d’une sorte de vin blanc nouveau.",
+                "n.  (Suisse) Vin non totalement fermenté, et commercialisable moyennant une pasteurisation.",
+                "n.  (Désuet) (Familier) Homme de mauvaise humeur."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui est d’une humeur brusque, fâchée et chagrine.",
+                "(Vieilli) (Sens propre) Qui est rempli de bourre, qui n’est pas lisse.",
+                "(Limousin) (Sens propre) Poilu.",
+                "(Vieilli) Mal dégrossie, en parlant d’une pierre de construction.",
+                "(Œnologie) Qui n’a pas totalement fermenté et qui se conserve doux dans le tonneau durant une semaine, en parlant d’une sorte de vin blanc nouveau.",
+                "(Suisse) Vin non totalement fermenté, et commercialisable moyennant une pasteurisation.",
+                "(Désuet) (Familier) Homme de mauvaise humeur."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 20, 2025**.