### PR TITLE
Add word of the day for June 22, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-06-22.json
+++ b/data/dicolink_word_of_the_day_2025-06-22.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Lapalissade",
+    "date": "June 22, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Vérité d'une évidence niaise."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Chose évidente, tautologique, réflexion niaise ou ridicule tant elle est évidente."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 22, 2025**.