### PR TITLE
Add word of the day for June 26, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-06-26.json
+++ b/data/dicolink_word_of_the_day_2025-06-26.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Sempervirent",
+    "date": "June 26, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Se dit des plantes qui portent des feuilles vertes toute l'année."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Botanique) Qui est toujours vert, recouvert de feuilles."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 26, 2025**.