### PR TITLE
Add word of the day for June 27, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-06-27.json
+++ b/data/dicolink_word_of_the_day_2025-06-27.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Bisbille",
+    "date": "June 27, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Familier. Brouille, querelle futile entre deux personnes : Être en bisbille avec un ami."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Murmure, petite querelle, dissension sur des futilités."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Murmure, petite querelle, dissension sur des futilités."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 27, 2025**.