### PR TITLE
Add word of the day for June 28, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-06-28.json
+++ b/data/dicolink_word_of_the_day_2025-06-28.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Dulcaquicole",
+    "date": "June 28, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui vit exclusivement dans les eaux douces. (Les plantes dulcicoles sont souvent appelées plantes aquatiques.)"
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui vit en eau douce."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 28, 2025**.