### PR TITLE
Add word of the day for June 29, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-06-29.json
+++ b/data/dicolink_word_of_the_day_2025-06-29.json
@@ -1,0 +1,26 @@
+{
+    "word_of_the_day": "Valétudinaire",
+    "date": "June 29, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj.n. Littéraire. Qui a une santé chancelante."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Vieilli) Qui est maladif, qui est souvent malade [2].",
+                "n.  Personne qui est valétudinaire, sujette aux maladies."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Qui est souvent malade.     Substantivement.:  Les convalescents et les valétudinaires."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 29, 2025**.