### PR TITLE
Add word of the day for June 30, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-06-30.json
+++ b/data/dicolink_word_of_the_day_2025-06-30.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Chancir",
+    "date": "June 30, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. intr. Vieux. Moisir."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  (Vieilli) Moisir. Il se dit surtout des choses comestibles."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Vieilli) Moisir (surtout en parlant de choses comestibles)."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 30, 2025**.