### PR TITLE
Add word of the day for July 14, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-07-14.json
+++ b/data/dicolink_word_of_the_day_2025-07-14.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Flaveur",
+    "date": "July 14, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Ensemble des sensations olfactives, gustatives et tactiles ressenties lors de la dégustation d'un produit alimentaire."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Ensemble des sensations perçues lors du flairage ou de la mise en bouche d’un aliment : olfaction, goût et nociception."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Ensemble des sensations perçues lors du flairage ou de la mise en bouche d’un aliment : olfaction, goût et nociception."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 14, 2025**.