### PR TITLE
Add word of the day for July 15, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-07-15.json
+++ b/data/dicolink_word_of_the_day_2025-07-15.json
@@ -1,0 +1,39 @@
+{
+    "word_of_the_day": "Satrape",
+    "date": "July 15, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Gouverneur d'une satrapie chez les Perses achéménides.",
+                "n.m. Littéraire. Personnage qui mène une vie fastueuse ou qui exerce une autorité despotique."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Titre des gouverneurs de province, chez les anciens Perses.",
+                "n.  (Par analogie) Personnage qui exerce une autorité despotique.",
+                "n.  (Figuré) Personne très riche qui mène grand train.",
+                "n.  (Par plaisanterie) Titre porté par certains membres du collège de pataphysique."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1: Titre des gouverneurs de province chez les anciens Perses.",
+                "Sens 2:  Fig. Se dit d'un homme fier et despotique."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Noblesse) Titre des gouverneurs de province, chez les anciens Perses.",
+                "(Par analogie) Personnage qui exerce une autorité despotique.",
+                "(Figuré) Personne très riche qui mène grand train.",
+                "(Par plaisanterie) Titre porté par certains membres du collège de pataphysique."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 15, 2025**.