### PR TITLE
Add word of the day for July 16, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-07-16.json
+++ b/data/dicolink_word_of_the_day_2025-07-16.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Malefaim",
+    "date": "July 16, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Désuet) Faim cruelle, dévorante."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Faim pressante."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Désuet) Faim cruelle, dévorante."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 16, 2025**.