### PR TITLE
Add word of the day for July 24, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-07-24.json
+++ b/data/dicolink_word_of_the_day_2025-07-24.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Soliloquer",
+    "date": "July 24, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. intr. Se parler à soi-même."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Se parler à soi-même."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 24, 2025**.