### PR TITLE
Add word of the day for July 25, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-07-25.json
+++ b/data/dicolink_word_of_the_day_2025-07-25.json
@@ -1,0 +1,31 @@
+{
+    "word_of_the_day": "Guignon",
+    "date": "July 25, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Vieux. Malchance persistante, en particulier au jeu."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Vieilli) (Familier) Malchance persistante."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Mauvaise chance, principalement au jeu.        Guignon guignonnant, sorte de génie malfaisant employé dans les contes d'enfant pour signifier ou expliquer des contrariétés successives."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Vieilli) (Familier) Malchance persistante."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 25, 2025**.