### PR TITLE
Add workflow PAT verification

### DIFF
--- a/.github/workflows/auto_merge_word_of_the_day.yml
+++ b/.github/workflows/auto_merge_word_of_the_day.yml
@@ -1,0 +1,41 @@
+name: Auto Merge Word of the Day PRs
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Verify Token Permissions
+        run: |
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/user)
+          if [ "$RESPONSE" -ne 200 ]; then
+            echo "Error: Personal Access Token (PAT) has insufficient permissions or is invalid."
+            exit 1
+          else
+            echo "PAT is valid and has the necessary permissions."
+          fi
+        shell: bash
+
+      - name: Merge PRs
+        env:
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          scripts/merge_word_of_the_day.sh

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ The following sequence diagram illustrates the workflow for fetching the word of
 4. **Automated Workflow:**
    - The GitHub Action workflow is set up to run automatically on a daily schedule.
    - It handles fetching, parsing, and storing new words, as well as creating pull requests when new data is available.
+   - Another workflow automatically merges pull requests with branches named `add-*word-of-the-day` into the `holding` branch every six hours.
+     The workflow uses the `PERSONAL_ACCESS_TOKEN` secret and verifies that the token has the correct permissions before merging.
+    You can also trigger this workflow manually on GitHub or run `scripts/merge_word_of_the_day.sh` locally. The script expects a `PERSONAL_ACCESS_TOKEN` environment variable containing a PAT with `repo` access.
 
 5. **Check the Data:**
    - After the script or workflow runs, check the `data/` directory for JSON files containing the latest word and its definitions.

--- a/scripts/merge_word_of_the_day.sh
+++ b/scripts/merge_word_of_the_day.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Merge pull requests with branch names matching 'add-.*word-of-the-day'
+# into the 'holding' branch.
+# Requires: curl, jq
+
+set -euo pipefail
+
+REPO=${1:-"${GITHUB_REPOSITORY:-}"}
+if [ -z "$REPO" ]; then
+  echo "Repository not specified. Pass as first argument or set GITHUB_REPOSITORY." >&2
+  exit 1
+fi
+
+if [ -z "${PERSONAL_ACCESS_TOKEN:-}" ]; then
+  echo "PERSONAL_ACCESS_TOKEN environment variable is required" >&2
+  exit 1
+fi
+
+PRS=$(curl -s -H "Authorization: Bearer $PERSONAL_ACCESS_TOKEN" -H "Accept: application/vnd.github+json" \
+          "https://api.github.com/repos/${REPO}/pulls?state=open&base=holding" | \
+          jq -r '.[] | select(.head.ref | test("add-.*word-of-the-day")) | .number')
+
+if [ -z "$PRS" ]; then
+  echo "No matching pull requests found" >&2
+  exit 0
+fi
+
+for pr in $PRS; do
+  echo "Merging PR #$pr" >&2
+  STATUS=$(curl -s -o /tmp/merge_out -w "%{http_code}" -X PUT \
+    -H "Authorization: Bearer $PERSONAL_ACCESS_TOKEN" -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${REPO}/pulls/${pr}/merge" \
+    -d '{"merge_method":"merge"}')
+  cat /tmp/merge_out
+  if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
+    echo "Successfully merged PR #$pr" >&2
+  else
+    echo "Failed to merge PR #$pr (status: $STATUS)" >&2
+  fi
+  rm -f /tmp/merge_out
+done


### PR DESCRIPTION
## Summary
- add step to verify Personal Access Token in auto merge workflow
- clarify token usage in README
- use PERSONAL_ACCESS_TOKEN variable in merge script and workflow

## Testing
- `python -m py_compile dicolink/dicolink.py robert/robert.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688260bb380c832ab435542f50fc8f7a