### PR TITLE
Add word of the day for July 28, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-07-28.json
+++ b/data/dicolink_word_of_the_day_2025-07-28.json
@@ -1,0 +1,29 @@
+{
+    "word_of_the_day": "Fuligineux",
+    "date": "July 28, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui produit de la suie : Flamme fuligineuse.",
+                "adj. Littéraire. Noirâtre comme la suie : Couleur fuligineuse.",
+                "adj. Littéraire. Obscur, qui manque de clarté : Un cerveau fuligineux.",
+                "adj. Recouvert de fuliginosités."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Littéraire) De couleur noirâtre, qui a les apparences de la suie."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Sens 1: Qui est de couleur de suie, noirâtre. Vapeurs fuligineuses, vapeurs qui portent avec elles une sorte de suie.",
+                "adj. Sens 2:  Terme de médecine. Lèvres, langue fuligineuses, lèvres, langue couvertes d'un enduit noirâtre.Ancien terme de médecine. Vapeurs fuligineuses, exhalaisons épaisses qu'on supposait partir du foie, de la rate, et obscurcir le cerveau."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 28, 2025**.