### PR TITLE
Add word of the day for July 29, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-07-29.json
+++ b/data/dicolink_word_of_the_day_2025-07-29.json
@@ -1,0 +1,35 @@
+{
+    "word_of_the_day": "Coterie",
+    "date": "July 29, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Péjoratif. Groupe de personnes qui se soutiennent pour faire prévaloir leurs intérêts : Une coterie littéraire."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Histoire) Société de villageois réunis pour tenir d’un seigneur quelque héritage.",
+                "n.  Groupe restreint de personnes liées par des intérêts ou des idées communes et qui cabalent contre ceux qui sont en dehors de ce groupe."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1: Mot ancien, qui signifiait un certain nombre de paysans, unis ensemble pour tenir les terres d'un seigneur.",
+                "Sens 2: Aujourd'hui, compagnie de personnes qui vivent entre elles familièrement, ou qui cabalent dans un intérêt commun."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Histoire) Société de villageois réunis pour tenir d’un seigneur quelque héritage.",
+                "(Histoire) Groupe d’ouvriers appartenant à un même corps de métier, spécialement dans le cadre du compagnonnage et des métiers du bâtiment.",
+                "(Péjoratif) Groupe restreint de personnes liées par des intérêts ou des idées communes et qui cabalent contre ceux qui sont en dehors de ce groupe."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 29, 2025**.