### PR TITLE
Add word of the day for July 31, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-07-31.json
+++ b/data/dicolink_word_of_the_day_2025-07-31.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Pandiculation",
+    "date": "July 31, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Action d'étendre les bras vers le haut et d'allonger les jambes en bâillant."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Médecine) Action automatique, et souvent forcée, par laquelle on porte les bras en haut, en renversant la tête et le tronc en arrière et en allongeant les jambes : elle a lieu ordinairement au réveil, ou lorsqu’on est très fatigué ou près de céder au sommeil."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 31, 2025**.