### PR TITLE
Add word of the day for August 18, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-08-18.json
+++ b/data/dicolink_word_of_the_day_2025-08-18.json
@@ -1,0 +1,39 @@
+{
+    "word_of_the_day": "Farceur",
+    "date": "August 18, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n. Personne qui n'agit ou ne parle pas sérieusement, qui fait continuellement des farces."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Celui, celle qui aime à faire ou à dire des choses bouffonnes ou à jouer des tours plaisants aux gens.",
+                "n.  Celui, de celle qui cherche à en faire accroire.",
+                "n.  (Vieilli) Comédien qui ne joue que dans les farces. Se dit encore par mépris d’un acteur qui charge un rôle comique.",
+                "(Figuré) Qui joue des farces."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1: Comédien, comédienne qui ne joue que dans les farces.   Ce mot se prend presque toujours en mauvaise part.",
+                "Sens 2:  Fig. Un homme qui est dans l'habitude de faire des bouffonneries.",
+                "Sens 3:  Populairement, il se dit d'un jeune homme, d'une jeune fille qui ont mauvaise conduite. Il s'est attaché à une grande farceuse du quartier.Il se dit aussi de celui qui se moque du monde, qui ne croit pas ce qu'il dit."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Celui, celle qui aime à faire ou à dire des choses bouffonnes ou à jouer des tours plaisants aux gens.",
+                "Celui, celle qui cherche à en faire accroire.",
+                "(Vieilli) Comédien qui ne joue que dans les farces. Se dit encore par mépris d’un acteur qui charge un rôle comique.",
+                "(Figuré) Qui joue des farces."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 18, 2025**.