### PR TITLE
Delete merged add branches and clarify Dicolink word-of-day PRs

### DIFF
--- a/.github/workflows/delete_add_branches.yml
+++ b/.github/workflows/delete_add_branches.yml
@@ -1,0 +1,32 @@
+name: Delete merged add branches
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'add')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Delete branch
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const headRepo = context.payload.pull_request.head.repo.full_name;
+            if (headRepo !== context.repo.owner + '/' + context.repo.repo) {
+              core.notice(`Skipping branch deletion because ${branch} is from a fork`);
+              return;
+            }
+            await github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `heads/${branch}`,
+            });
+            core.info(`Deleted branch ${branch}`);

--- a/.github/workflows/fetch_dicolink_word_of_the_day.yml
+++ b/.github/workflows/fetch_dicolink_word_of_the_day.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Commit changes
         run: |
           git add data/
-          git commit -m "Add word of the day for ${{ env.RAW_DATE }}" || echo "No changes to commit."
+          git commit -m "Add Dicolink word of the day for ${{ env.RAW_DATE }}" || echo "No changes to commit."
 
       # Step 10: Detect if holding has new data compared to main
       - name: Detect new data compared to main
@@ -210,9 +210,9 @@ jobs:
         uses: peter-evans/create-pull-request@v7.0.6
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}  # Use PAT with appropriate permissions
-          commit-message: "Add word of the day for ${{ env.RAW_DATE }}"
+          commit-message: "Add Dicolink word of the day for ${{ env.RAW_DATE }}"
           branch: add-dicolink-word-of-the-day-${{ env.DATE }}   # Modifié ici
-          title: "Add word of the day for ${{ env.RAW_DATE }}"
+          title: "Add Dicolink word of the day for ${{ env.RAW_DATE }}"
           body: "Automatically added the Dicolink word of the day for **${{ env.RAW_DATE }}**."
           base: ${{ env.HOLDING_BRANCH }}
           delete-branch: false  # Do not delete the branch if changes are added
@@ -223,9 +223,9 @@ jobs:
         uses: peter-evans/create-pull-request@v7.0.6
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}  # Use PAT with appropriate permissions
-          commit-message: "Add word of the day for ${{ env.RAW_DATE }}"
+          commit-message: "Add Dicolink word of the day for ${{ env.RAW_DATE }}"
           branch: add-dicolink-word-of-the-day-${{ env.DATE }}   # Modifié ici
-          title: "Add word of the day for ${{ env.RAW_DATE }}"
+          title: "Add Dicolink word of the day for ${{ env.RAW_DATE }}"
           body: "Automatically added the Dicolink word of the day for **${{ env.RAW_DATE }}**."
           base: ${{ env.BRANCH_NAME || 'main' }}
           delete-branch: true  # Delete the branch after merging

--- a/.github/workflows/promote_holding.yml
+++ b/.github/workflows/promote_holding.yml
@@ -1,0 +1,34 @@
+name: Promote holding to dev and main
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Merge holding into dev and sync to main
+        run: |
+          set -e
+          git fetch origin holding dev main
+          git checkout dev
+          git merge origin/holding --no-ff -m "Merge holding into dev"
+          git push origin dev
+
+          git checkout main
+          git merge origin/dev --no-ff -m "Sync dev into main"
+          git push origin main


### PR DESCRIPTION
## Summary
- add workflow to remove branches starting with `add` after their PRs merge
- promote the `holding` branch into `dev` and sync `dev` with `main`
- rename Dicolink workflow and tag its PRs as `Dicolink word of the day`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a98627eea8832ab7cd5871a69b0375