### PR TITLE
Add Dicolink word of the day for August 25, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-08-25.json
+++ b/data/dicolink_word_of_the_day_2025-08-25.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "Logomachie",
+    "date": "August 25, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Littéraire. Discussion sur les mots ou dans laquelle les interlocuteurs emploient les mêmes mots dans des sens différents.",
+                "n.f. Assemblage de mots creux dans un discours, dans un raisonnement."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Didactique) Dispute de mots, usage de termes creux."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 25, 2025**.