### PR TITLE
Add Dicolink word of the day for August 28, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-08-28.json
+++ b/data/dicolink_word_of_the_day_2025-08-28.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Rubescent",
+    "date": "August 28, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Qui devient rouge."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui est un peu rouge ; qui commence à rougir."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj.  Terme didactique. Un peu rouge, qui commence à rougir."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 28, 2025**.