### PR TITLE
Add Dicolink word of the day for August 29, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-08-29.json
+++ b/data/dicolink_word_of_the_day_2025-08-29.json
@@ -1,0 +1,32 @@
+{
+    "word_of_the_day": "Vénusté",
+    "date": "August 29, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Littéraire. Beauté gracieuse et élégante."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Rare) (Littéraire) Beau, gracieux, élégant.",
+                "Destiné à l’amour, dédié à Vénus."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Grâce, élégance (latinisme peu usité)."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Littéraire) Beauté gracieuse et élégante."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 29, 2025**.