### PR TITLE
Add Dicolink word of the day for September 03, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-09-03.json
+++ b/data/dicolink_word_of_the_day_2025-09-03.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Pétuner",
+    "date": "September 03, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. intr. Vieux. Fumer du tabac."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  (Ironique), (Vieilli) Fumer ou priser du tabac."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Ironique) (Vieilli) Fumer ou priser du tabac."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **September 03, 2025**.