### PR TITLE
Add Dicolink word of the day for September 09, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-09-09.json
+++ b/data/dicolink_word_of_the_day_2025-09-09.json
@@ -1,0 +1,36 @@
+{
+    "word_of_the_day": "Syzygie",
+    "date": "September 09, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Nouvelle lune ou pleine lune."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Astronomie) Position de la lune en conjonction ou en opposition avec le soleil, ce qui correspond à la nouvelle lune et à la pleine lune.",
+                "n.  (Algèbre) Relation entre les générateurs d'un module."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1:  Terme d'astronomie. Positions du soleil et de la lune, quand ces astres sont en conjonction ou en opposition, c'est-à-dire à la nouvelle et à la pleine lune.  Il se dit aussi des planètes.",
+                "Sens 2:  Terme de métrique ancienne. Réunion de plusieurs pieds en un seul. Le latin libertate est un épitrite formé par syzygie d'un spondée et d'un trochée.",
+                "Sens 3: Syzygies valentiniennes, dans le gnosticisme, déterminations successives et personnelles de l'essence divine, se déroulant deux par deux, chaque éon masculin ayant à côté de lui un éon féminin (voy. OGDOADE)."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Astronomie) Situation de trois corps célestes ou plus en conjonction ou en opposition. Se dit particulièrement pour la Lune avec la nouvelle lune et la pleine lune.",
+                "(Algèbre) Relation entre les générateurs d’un module.",
+                "(Philosophie) Paire d’éons dans la pensée gnostique."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **September 09, 2025**.