### PR TITLE
Add Dicolink word of the day for September 11, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-09-11.json
+++ b/data/dicolink_word_of_the_day_2025-09-11.json
@@ -1,0 +1,26 @@
+{
+    "word_of_the_day": "Déblatérer",
+    "date": "September 11, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Familier. Parler longuement et avec hostilité contre quelqu'un, quelque chose : Déblatérer contre ses voisins."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  (Rare) Proférer."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Parler fort, longtemps et avec violence ou véhémence contre — (Plus rare) sur — quelqu’un ou quelque chose.",
+                "(Rare) Proférer."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **September 11, 2025**.