### PR TITLE
Add Dicolink word of the day for September 16, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-09-16.json
+++ b/data/dicolink_word_of_the_day_2025-09-16.json
@@ -1,0 +1,33 @@
+{
+    "word_of_the_day": "Remugle",
+    "date": "September 16, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Littéraire. Odeur particulière que contractent les objets longtemps renfermés ou exposés à un mauvais air."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Odeur désagréable de moisi, humidité ou renfermé. Relent.",
+                "n.  (Figuré) (Péjoratif) Relent."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Terme vieilli. Odeur de ce qui a été longtemps enfermé ou exposé à un mauvais air."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Odeur désagréable de moisi, humidité ou renfermé. Relent.",
+                "(Figuré) (Péjoratif) Relent."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **September 16, 2025**.