### PR TITLE
Add Dicolink word of the day for September 17, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-09-17.json
+++ b/data/dicolink_word_of_the_day_2025-09-17.json
@@ -1,0 +1,26 @@
+{
+    "word_of_the_day": "Pétulant",
+    "date": "September 17, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui manifeste un dynamisme extrême."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui est vif, brusque, impétueux, qui peine à se contenir."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui est vif, brusque, impétueux, qui peine à se contenir.",
+                "Participe présent de pétuler."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **September 17, 2025**.