### PR TITLE
Add Dicolink word of the day for September 18, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-09-18.json
+++ b/data/dicolink_word_of_the_day_2025-09-18.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Dispendieux",
+    "date": "September 18, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Qui nécessite une grande dépense, de grands frais ; cher, onéreux : Train de vie dispendieux."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui exige beaucoup de dépenses.",
+                "(Canada) ou (Vieilli) en (France) Cher."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui exige beaucoup de dépenses.",
+                "(Canada) ou (Vieilli) en (France) Cher."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **September 18, 2025**.