### PR TITLE
Add Dicolink word of the day for September 20, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-09-20.json
+++ b/data/dicolink_word_of_the_day_2025-09-20.json
@@ -1,0 +1,31 @@
+{
+    "word_of_the_day": "Démascler",
+    "date": "September 20, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Pratiquer le démasclage."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Dépouiller un chêne-liège de la première écorce, pour que le liège puisse se former ensuite régulièrement."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "v. tr. Opérer le démasclage."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Dépouiller un chêne-liège de la première écorce, pour que le liège puisse se former ensuite régulièrement."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **September 20, 2025**.