### PR TITLE
Add Dicolink word of the day for September 22, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-09-22.json
+++ b/data/dicolink_word_of_the_day_2025-09-22.json
@@ -1,0 +1,31 @@
+{
+    "word_of_the_day": "Jovien",
+    "date": "September 22, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Relatif à la planète Jupiter."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui se rapporte au dieu Jupiter.",
+                "Qui se rapporte à la planète Jupiter.",
+                "Relatif à Job, commune française située dans le département du Puy-de-Dôme.",
+                "Relatif à Jouy, commune française située dans le département de l’Eure-et-Loir."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui se rapporte au dieu Jupiter.",
+                "Qui se rapporte à la planète Jupiter.",
+                "Relatif à Job, commune française située dans le département du Puy-de-Dôme.",
+                "Relatif à Jouy, commune française située dans le département de l’Eure-et-Loir."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **September 22, 2025**.