### PR TITLE
Add Dicolink word of the day for September 25, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-09-25.json
+++ b/data/dicolink_word_of_the_day_2025-09-25.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Scripophilie",
+    "date": "September 25, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Recherche, collection des actions et obligations qui ne sont plus cotées en Bourse."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Collection des anciens titres de bourse et des actions."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **September 25, 2025**.