### PR TITLE
Add Dicolink word of the day for September 26, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-09-26.json
+++ b/data/dicolink_word_of_the_day_2025-09-26.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Eburneen",
+    "date": "September 26, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Qui a l'aspect, la blancheur de l'ivoire."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui a l’apparence de l’ivoire."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **September 26, 2025**.