### PR TITLE
Add Dicolink word of the day for September 28, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-09-28.json
+++ b/data/dicolink_word_of_the_day_2025-09-28.json
@@ -1,0 +1,37 @@
+{
+    "word_of_the_day": "Ilote",
+    "date": "September 28, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Esclave public à Sparte.",
+                "n.m. Littéraire. Personne réduite au dernier degré d'ignorance ou de soumission."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Habitant de la Laconie réduit à l’esclavage par les Spartiates.",
+                "n.  (Littéraire) Personne asservie, réduite à la misère et à l’ignorance.",
+                "Réduit à l’état d’ilote."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1: Nom d'esclaves, dans la république de Sparte, qui cultivaient les champs de leurs maîtres, leur remettaient une partie déterminée du produit, et les accompagnaient à la guerre comme serviteurs ; c'étaient les anciens habitants du pays subjugués par les Doriens victorieux.",
+                "Sens 2:  Fig. Celui qui est réduit, dans une société, au dernier état d'abjection ou d'ignorance."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Histoire) Habitant de la Laconie réduit à l’esclavage par les Spartiates.",
+                "(Littéraire) (Figuré) Personne asservie, réduite à la misère et à l’ignorance.",
+                "Esclave."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **September 28, 2025**.