### PR TITLE
Add Dicolink word of the day for September 29, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-09-29.json
+++ b/data/dicolink_word_of_the_day_2025-09-29.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Rocambolesque",
+    "date": "September 29, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui est plein d'invraisemblance, de péripéties extraordinaires : Aventures rocambolesques."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Plein de rebondissements, d’aventures remplies de péripéties invraisemblables, extraordinaires."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **September 29, 2025**.