### PR TITLE
Add Dicolink word of the day for October 02, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-10-02.json
+++ b/data/dicolink_word_of_the_day_2025-10-02.json
@@ -1,0 +1,28 @@
+{
+    "word_of_the_day": "Flapi",
+    "date": "October 02, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "Familier. Être extrêmement fatigué."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Familier) Qui est extrêmement fatigué."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Familier) Extrêmement fatigué.",
+                "(Lyonnais) Flasque, mou.",
+                "(Lyonnais) (se dit d'un végétal) Flétri.",
+                "Participe passé masculin singulier de flapir."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **October 02, 2025**.