### PR TITLE
Add Dicolink word of the day for October 06, 2025

### DIFF
--- a/data/dicolink_word_of_the_day_2025-10-06.json
+++ b/data/dicolink_word_of_the_day_2025-10-06.json
@@ -1,0 +1,31 @@
+{
+    "word_of_the_day": "Hâblerie",
+    "date": "October 06, 2025",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Littéraire. Discours plein d'exagération, de suffisance."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Discours plein d'exagération, d’emphase, de vanterie. Mensonge débité avec assurance et ostentation."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Langage de celui qui hâble."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Discours plein d'exagération, d’emphase, de vanterie. Mensonge débité avec assurance et ostentation."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **October 06, 2025**.