### PR TITLE
Add Dicolink word of the day for April 03, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-03.json
+++ b/data/dicolink_word_of_the_day_2026-04-03.json
@@ -1,0 +1,31 @@
+{
+    "word_of_the_day": "Pérorer",
+    "date": "April 03, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. intr. Discourir d'une façon prolixe et prétentieuse."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Parler, discourir longuement et avec une sorte d’emphase."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Discourir longuement et avec prétention.  Il se conjugue avec l'auxiliaire avoir. Activement."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Parler, discourir longuement et avec une sorte d’emphase."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 03, 2026**.