### PR TITLE
Add Dicolink word of the day for April 04, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-04.json
+++ b/data/dicolink_word_of_the_day_2026-04-04.json
@@ -1,0 +1,29 @@
+{
+    "word_of_the_day": "Giboulée",
+    "date": "April 04, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Grosse averse soudaine, généralement courte, souvent accompagnée de grêle : Les giboulées de mars."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Pluie soudaine, de courte durée, et quelquefois mêlée de grêle ou de neige.",
+                "n.  (Figuré) Volée de coups.",
+                "n.  (Par extension) Arrivée soudaine, implacable, de choses en grande quantité : maladies, insultes, objets, etc."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Météorologie) Pluie soudaine, de courte durée, et quelquefois mêlée de grêle ou de neige.",
+                "(Figuré) Volée de coups.",
+                "(Par extension) Arrivée soudaine, implacable, de choses en grande quantité : maladies, insultes, objets, etc."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 04, 2026**.