### PR TITLE
Add Dicolink word of the day for April 05, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-05.json
+++ b/data/dicolink_word_of_the_day_2026-04-05.json
@@ -1,0 +1,22 @@
+{
+    "word_of_the_day": "Indigence",
+    "date": "April 05, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. État de quelqu'un d'indigent : Tomber dans l'indigence.",
+                "n.f. État de pauvreté intellectuelle, morale : Indigence d'idées."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Grande pauvreté, privation du nécessaire.",
+                "n.  État de pauvreté qui appelle les secours publics ou privés.",
+                "n.  Ensemble des indigents."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 05, 2026**.