### PR TITLE
Add Dicolink word of the day for April 06, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-06.json
+++ b/data/dicolink_word_of_the_day_2026-04-06.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Bouleux",
+    "date": "April 06, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj.n. Se dit d'un cheval trapu et résistant à la fatigue."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui n’est propre qu’à des services de fatigue, en parlant d’un cheval trapu et robuste.",
+                "Travailleur."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui n’est propre qu’à des services de fatigue, en parlant d’un cheval trapu et robuste.",
+                "Travailleur."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 06, 2026**.