### PR TITLE
Add Dicolink word of the day for April 09, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-09.json
+++ b/data/dicolink_word_of_the_day_2026-04-09.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "époustouflant",
+    "date": "April 09, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui étonne, qui cause une grande surprise par son caractère inattendu ; stupéfiant : Une nouvelle époustouflante.",
+                "adj. Qui provoque une vive admiration, qui stupéfie par son caractère extraordinaire, prodigieux : Un acteur époustouflant."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Sidérant."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 09, 2026**.