### PR TITLE
Add Dicolink word of the day for April 10, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-10.json
+++ b/data/dicolink_word_of_the_day_2026-04-10.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Boustrophédon",
+    "date": "April 10, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Écriture archaïque (grec, étrusque, etc.) dont les lignes se lisaient alternativement de gauche à droite puis de droite à gauche, à la manière des sillons tracés dans un champ."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Linguistique) Tracé d’un système d’écriture qui change alternativement de sens, ligne après ligne, de droite à gauche (lecture sinistroverse) puis de gauche à droite (lecture dextroverse)."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 10, 2026**.