### PR TITLE
Add Dicolink word of the day for April 11, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-11.json
+++ b/data/dicolink_word_of_the_day_2026-04-11.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Vantard",
+    "date": "April 11, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj.n. Se dit de quelqu'un qui aime se vanter de ses propos."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui a l’habitude de se vanter.",
+                "n.  Personne se vantant facilement."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui a l’habitude de se vanter.",
+                "Personne se vantant facilement."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 11, 2026**.