### PR TITLE
Add Dicolink word of the day for April 12, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-12.json
+++ b/data/dicolink_word_of_the_day_2026-04-12.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Fébricule",
+    "date": "April 12, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Fièvre de faible importance évoluant entre 37,2 °C et 37,8 °C et témoignant le plus souvent d'une infection bénigne."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Médecine) Petite fièvre; fièvre hectique légère."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Terme de médecine. Petite fièvre ; fièvre hectique légère."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 12, 2026**.