### PR TITLE
Add Dicolink word of the day for April 13, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-13.json
+++ b/data/dicolink_word_of_the_day_2026-04-13.json
@@ -1,0 +1,45 @@
+{
+    "word_of_the_day": "Indolent",
+    "date": "April 13, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj.n. Qui évite de se donner de la peine, qui agit avec mollesse : Un enfant indolent. Un geste indolent."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui est porté à éviter tout effort, toute peine.",
+                "Qui est insensible à la plupart des choses qui touchent ordinairement les autres hommes.",
+                "(Littéraire) Qui fait penser à la nonchalance, à la mollesse.",
+                "(Médecine) (Oncologie) À développement lent. Note : À ne pas confondre avec indolore « Qui ne cause point de douleur. »",
+                "(Médecine) Qui ne cause point de douleur. Note : Ce sens est-il vieilli ?",
+                "n."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Sens 2: Privé de sensibilité morale, sur qui rien ne fait impression. C'est un homme indolent qui ne s'émeut de rien.  Il se dit des choses en un sens analogue.",
+                "adj. Sens 4:  S. m. et f.:  Un indolent. Une indolente. C'est un grand indolent qui ne se met en peine de rien.",
+                "adj. Sens 3: Qui ne se donne pas de peine.     Il se dit des choses, en un sens analogue.",
+                "adj. Sens 1:  Terme de médecine. Qui ne cause pas de douleur."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Désuet) (Médecine) Qui ne cause pas de douleur, indolore.",
+                "(Médecine) À développement lent, par opposition à agressif.",
+                "Insensible, qui ne se laisse pas affecter.",
+                "Nonchalant.",
+                "Qui manque de vivacité.",
+                "(Littéraire) Qui fait penser à la nonchalance, à la mollesse.",
+                "Personne nonchalante."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 13, 2026**.