### PR TITLE
Add Dicolink word of the day for April 14, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-14.json
+++ b/data/dicolink_word_of_the_day_2026-04-14.json
@@ -1,0 +1,32 @@
+{
+    "word_of_the_day": "Obvie",
+    "date": "April 14, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Se dit en philosophie et en théologie du sens d'un terme ou d'un texte qui vient spontanément à l'esprit."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Philologie) Sens obvie : sens d’un mot, d’une expression, qui est celui que l’esprit lui donne sans réflexion et abstraction faite du contexte.",
+                "Qui est évident, dont le sens vient naturellement à l’esprit."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Philologie) Caractérise le sens d’un mot, d’une expression, qui est celui que l’esprit lui donne sans réflexion et abstraction faite du contexte.",
+                "Qui est évident, dont le sens vient naturellement à l’esprit.",
+                "Première personne du singulier du présent de l’indicatif de obvier.",
+                "Troisième personne du singulier du présent de l’indicatif de obvier.",
+                "Première personne du singulier du présent du subjonctif de obvier.",
+                "Troisième personne du singulier du présent du subjonctif de obvier.",
+                "Deuxième personne du singulier de l’impératif de obvier."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 14, 2026**.