### PR TITLE
Add Dicolink word of the day for April 15, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-15.json
+++ b/data/dicolink_word_of_the_day_2026-04-15.json
@@ -1,0 +1,29 @@
+{
+    "word_of_the_day": "Clampin",
+    "date": "April 15, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Familier, vieilli. Individu quelconque, généralement lent et paresseux."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Familier) Celui qui traine derrière un groupe et en ralentit la marche.",
+                "n.  Paresseux, cossard, fainéant, tire-au-flanc.",
+                "n.  (Familier) Personne quelconque, quidam."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Familier) Celui qui traine derrière un groupe et en ralentit la marche.",
+                "Paresseux, cossard, fainéant, tire-au-flanc.",
+                "(Familier) Personne quelconque ; quidam."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 15, 2026**.