### PR TITLE
Add Dicolink word of the day for April 16, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-16.json
+++ b/data/dicolink_word_of_the_day_2026-04-16.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Irascible",
+    "date": "April 16, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui est prompt à s'irriter : La fatigue le rend irascible."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui s’emporte facilement, qui est prompt à se mettre en colère.",
+                "(Philosophie scolastique) Qualifie la faculté par laquelle l’âme se porte à surmonter les difficultés qu’elle rencontre dans la poursuite du bien ou dans la fuite du mal."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Sens 1: Qui s'irrite facilement, promptement. Homme irascible.",
+                "adj. Sens 2:  Terme de philosophie scolastique. L'appétit irascible, la partie irascible, la faculté irascible, la faculté par laquelle l'âme s'irrite et s'emporte."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 16, 2026**.