### PR TITLE
Add Dicolink word of the day for April 18, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-18.json
+++ b/data/dicolink_word_of_the_day_2026-04-18.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "Sybaritisme",
+    "date": "April 18, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Littéraire. Raffinement dans la manière de vivre."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Fait de vouloir vivre comme les Sybarites, dans le plaisir et la luxure.",
+                "n.  Goût de luxe, mollesse, délicatesse exagérée."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 18, 2026**.