### PR TITLE
Add Robert word of the day for April 19, 2026

### DIFF
--- a/data/robert_word_of_the_day_2026-04-19.json
+++ b/data/robert_word_of_the_day_2026-04-19.json
@@ -1,0 +1,8 @@
+{
+    "word_of_the_day": "Suggestions proposées pour\n    \n    \n    mot-du-jour",
+    "date": "April 19, 2026",
+    "source_url": "https://dictionnaire.lerobert.com/mot-du-jour",
+    "definitions": [
+        "modulor"
+    ]
+}


### PR DESCRIPTION
Automatically added the Robert word of the day for **April 19, 2026**.