### PR TITLE
Add Dicolink word of the day for April 19, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-19.json
+++ b/data/dicolink_word_of_the_day_2026-04-19.json
@@ -1,0 +1,36 @@
+{
+    "word_of_the_day": "Harceler",
+    "date": "April 19, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Soumettre quelqu'un, un groupe à d'incessantes petites attaques : Harceler l'ennemi.",
+                "v. tr. Soumettre quelqu'un à des demandes, des critiques, des réclamations continuelles : Les journalistes harcelèrent le ministre de questions.",
+                "v. tr. Soumettre quelqu'un à de continuelles pressions, sollicitations : Il faut le harceler pour obtenir quelque chose."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Provoquer, exciter parfois jusqu’à importuner, jusqu’à tourmenter.",
+                "v.  (Militaire) Inquiéter, fatiguer par de fréquentes attaques, par de fréquentes escarmouches."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "v. tr. Sens 1: Tourmenter, inquiéter par de petites mais de fréquentes attaques.    Harceler les ennemis, les inquiéter, les fatiguer par de fréquentes attaques.   Par extension.",
+                "v. tr. Sens 2: Se harceler, v. réfl.:  Se tourmenter l'un l'autre. Ils se sont harcelés de propos piquants."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Provoquer, exciter parfois jusqu’à importuner, jusqu’à tourmenter.",
+                "(Militaire) Inquiéter, fatiguer par de fréquentes attaques, par de fréquentes escarmouches."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 19, 2026**.