### PR TITLE
Add Dicolink word of the day for April 20, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-20.json
+++ b/data/dicolink_word_of_the_day_2026-04-20.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Agoraphobie",
+    "date": "April 20, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Phobie des espaces découverts (places) et des lieux publics."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Médecine) Peur irraisonnée des espaces libres et des lieux publics, de se retrouver dans une situation embarrassante dans de tels lieux."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Médecine) Peur irraisonnée des espaces libres et des lieux publics, de se retrouver dans une situation embarrassante dans de tels lieux."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 20, 2026**.