### PR TITLE
Add Dicolink word of the day for April 21, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-21.json
+++ b/data/dicolink_word_of_the_day_2026-04-21.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "Tendancieux",
+    "date": "April 21, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui n'est pas objectif, qui manifeste une tendance idéologique, des idées qui déforment : Article tendancieux. Un critique tendancieux."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qualifie des paroles ou des écrits qui laissent deviner certaines tendances sans les marquer explicitement.",
+                "(Par extension) Qualifie une notion partiale, engagée, injuste, intolérante, sectaire ou partisane."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 21, 2026**.