### PR TITLE
Add Dicolink word of the day for April 22, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-22.json
+++ b/data/dicolink_word_of_the_day_2026-04-22.json
@@ -1,0 +1,28 @@
+{
+    "word_of_the_day": "Mélopée",
+    "date": "April 22, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Chant, mélodie, musique assez monotone et triste."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Antiquité) Composition du chant, on ne l’emploie qu’en parlant de la musique antique.",
+                "n.  (Musique) Déclamation chantée, chant récitatif, chant monotone."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Antiquité) Composition du chant, on ne l’emploie qu’en parlant de la musique antique.",
+                "(Musique) Déclamation chantée ; chant récitatif ; chant monotone.",
+                "Participe passé féminin singulier de méloper."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 22, 2026**.