### PR TITLE
Add Dicolink word of the day for April 23, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-23.json
+++ b/data/dicolink_word_of_the_day_2026-04-23.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Oxymore",
+    "date": "April 23, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. RhétoriqueFigure de style qui réunit deux mots en apparence contradictoires. (Exemple : un silence éloquent.)"
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Rhétorique) Combinaison dans un même groupe syntaxique de deux notions contradictoires."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Rhétorique) Alliance de mots surprenante. Association étroite de deux mots de sens contraires pour renforcer une idée."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 23, 2026**.