### PR TITLE
Add Dicolink word of the day for April 24, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-24.json
+++ b/data/dicolink_word_of_the_day_2026-04-24.json
@@ -1,0 +1,38 @@
+{
+    "word_of_the_day": "Louvoyer",
+    "date": "April 24, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. intr. Courir des bordées, bâbord et tribord amures, pour atteindre en zigzag un point où la direction du vent ne permet pas d'arriver directement.",
+                "v. intr. Suivre un chemin qui fait des détours ou des zigzags : Ivrogne qui louvoie sur le trottoir.",
+                "v. intr. Prendre des biais pour atteindre son but : Louvoyer devant des difficultés."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  (Marine) Faire plusieurs routes en zigzag au plus près du vent, en lui présentant tantôt un côté du bâtiment, tantôt l’autre.",
+                "v.  (Par analogie) Avancer en zigzaguant.",
+                "v.  (Figuré) Prendre des détours pour arriver à son but ; éviter de se prononcer."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1:  Terme de marine. Porter le cap d'un côté, et puis revirer de l'autre, pour ménager un vent contraire et ne pas s'éloigner de la route qu'on veut tenir.",
+                "Sens 2:  Fig. Prendre des détours pour arriver à un but où l'on ne peut aller directement.  Il se conjugue avec l'auxiliaire avoir."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Marine) Faire plusieurs routes en zigzag au plus près du vent, en lui présentant tantôt un côté du bâtiment, tantôt l’autre.",
+                "(Par analogie) Avancer en zigzaguant.",
+                "(Figuré) Prendre des détours pour arriver à son but ; éviter de se prononcer."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 24, 2026**.