### PR TITLE
Add Dicolink word of the day for April 25, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-25.json
+++ b/data/dicolink_word_of_the_day_2026-04-25.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "Primesautier",
+    "date": "April 25, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui décide, agit selon son premier mouvement, ses impulsions : Un adolescent primesautier.",
+                "adj. Qui est vif, alerte, plein de spontanéité : Humeur primesautière."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui se détermine, qui agit, qui parle ou qui écrit de premier mouvement, sans délibération, sans réflexion préalable."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 25, 2026**.