### PR TITLE
Add Dicolink word of the day for April 26, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-26.json
+++ b/data/dicolink_word_of_the_day_2026-04-26.json
@@ -1,0 +1,22 @@
+{
+    "word_of_the_day": "Hypocondriaque",
+    "date": "April 26, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj.n. Relatif à l'hypocondrie ; atteint d'hypocondrie."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Médecine) Qui appartient à la maladie hypocondrie.",
+                "Qui est atteint d’hypocondrie.",
+                "n.  Personne qui se préoccupe abusivement de sa santé.",
+                "n.  Personne ayant constamment l’impression qu'elle est ou va tomber malade."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 26, 2026**.