### PR TITLE
Add Dicolink word of the day for April 27, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-27.json
+++ b/data/dicolink_word_of_the_day_2026-04-27.json
@@ -1,0 +1,32 @@
+{
+    "word_of_the_day": "Aphorisme",
+    "date": "April 27, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Phrase, sentence qui résume en quelques mots une vérité fondamentale. (Exemple : Rien n'est beau que le vrai.)",
+                "n.m. Énoncé succinct d'une vérité banale. (Exemple : Pas de nouvelles, bonnes nouvelles.)"
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Courte phrase exprimant un principe ou un concept de pensée."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sentence renfermant un grand sens en peu de mots. Les aphorismes d'Hippocrate."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Rhétorique) Courte phrase exprimant un principe ou un concept de pensée, souvent par un assemblage d'idées paradoxal, surprenant, voire comique."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 27, 2026**.