### PR TITLE
Add Dicolink word of the day for April 28, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-28.json
+++ b/data/dicolink_word_of_the_day_2026-04-28.json
@@ -1,0 +1,35 @@
+{
+    "word_of_the_day": "Isthme",
+    "date": "April 28, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Bande de terre étroite, située entre deux mers et réunissant deux terres.",
+                "n.m. Nom donné à certaines parties rétrécies d'une région du corps ou d'un organe (par exemple l'isthme de l'encéphale, du gosier, de l'utérus, d'une vertèbre)."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Anatomie) Certaines parties qui ont quelque ressemblance de forme avec un isthme.",
+                "n.  (Géographie) Langue de terre entre deux mers ou deux golfes, qui joint une terre à une autre, une presqu’île au continent."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1:  Terme de géographie. Langue de terre qui sépare deux mers et joint deux terres.   Fig. Percer l'isthme, s'est dit quelquefois, à l'imitation d'une locution ancienne, pour tenter une chose impossible, plusieurs empereurs romains ayant essayé de percer l'isthme de Corinthe et y ayant renoncé.",
+                "Sens 2: Nom donné, en termes d'anatomie à certaines parties qui ont quelque ressemblance de forme avec un isthme. L'isthme du gosier.Isthme de Vieussens, relief de fibres musculaires qui règne tout autour de la fosse ovale de la cloison des oreillettes du cœur.  Terme de botanique. Étranglement qui sépare deux loges ou articles dans un fruit articulé."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Géographie) Langue de terre entre deux mers ou deux golfes, qui joint une terre à une autre, une presqu’île au continent.",
+                "(Par analogie) (Anatomie) Partie du corps qui a quelque ressemblance de forme avec un passage étroit."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 28, 2026**.