### PR TITLE
Add Dicolink word of the day for April 29, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-29.json
+++ b/data/dicolink_word_of_the_day_2026-04-29.json
@@ -1,0 +1,21 @@
+{
+    "word_of_the_day": "Lassitude",
+    "date": "April 29, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. État de grande fatigue physique : Sentir une grande lassitude dans les jambes.",
+                "n.f. État de grande fatigue morale : Être pris d'une immense lassitude devant les difficultés."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Sensation de fatigue causée par une mauvaise disposition de santé.",
+                "n.  État de celui qui est las, de celle qui est lasse, au propre et au figuré."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 29, 2026**.