### PR TITLE
Add Dicolink word of the day for April 30, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-04-30.json
+++ b/data/dicolink_word_of_the_day_2026-04-30.json
@@ -1,0 +1,34 @@
+{
+    "word_of_the_day": "Sagittal",
+    "date": "April 30, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Orienté d'arrière en avant. (Le plan sagittal, ou plan de symétrie du corps des animaux, est à la fois perpendiculaire aux plans transversaux et aux plans frontaux.)"
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Anatomie) Qui a la forme d’une flèche. (En particulier) (Anatomie) Qualifie les sutures du crâne qui sépare les deux pariétaux."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Sens 1:  Terme de botanique. Qui porte des espèces de flèches.",
+                "adj. Sens 2:  Terme d'anatomie. Qui ressemble à une flèche.Suture sagittale, suture du crâne qui, unissant les deux pariétaux, s'étend d'avant en arrière sur la ligne médiane. Gouttière sagittale, sillon profond creusé sur la suture des pariétaux, à la partie interne de la voûte du crâne, depuis la crête coronale jusqu'à la protubérance occipitale interne, et dans lequel est logé le sinus longitudinal supérieur, aussi quelquefois sagittal."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Anatomie) Qui a la forme d’une flèche.",
+                "(En particulier) (Anatomie) Qualifie les sutures du crâne qui sépare les deux pariétaux.",
+                "(Médecine) Indique l’orientation d’une coupe ou de vues dans les schémas et images en médecine ou en biologie humaine à partir de la position de Poirier, c’est-à-dire lorsque le patient est debout face à l’observateur. Le plan de coupe traverse le sujet verticalement dans le sens antéro-postérieur, comme le ferait une flèche tirée par l’observateur."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **April 30, 2026**.