### PR TITLE
Add Dicolink word of the day for May 01, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-01.json
+++ b/data/dicolink_word_of_the_day_2026-05-01.json
@@ -1,0 +1,30 @@
+{
+    "word_of_the_day": "Sybarite",
+    "date": "May 01, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj.n. De Sybaris.",
+                "adj.n. Littéraire. Qui recherche les plaisirs raffinés d'une existence passée dans le luxe."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui appartient à Sybaris ou à ses habitants.",
+                "(Par extension) Qui est mou, efféminé, corrompu, qui vit dans les plaisirs et la luxure comme les Sybarites.",
+                "n.  Homme qui mène une vie molle et voluptueuse, par allusion aux anciens habitants de la ville de Sybaris."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui appartient à Sybaris ou à ses habitants.",
+                "(Par extension) Qui est mou, efféminé, corrompu, qui vit dans les plaisirs et la luxure comme les Sybarites.",
+                "Personne qui mène une vie molle et voluptueuse, par allusion aux anciens habitants de la ville de Sybaris."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 01, 2026**.