### PR TITLE
Add Dicolink word of the day for May 02, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-02.json
+++ b/data/dicolink_word_of_the_day_2026-05-02.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Pusillanime",
+    "date": "May 02, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj.n. Littéraire. Qui manque d'audace, de courage."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Littéraire) Qui manque de courage, de caractère ; qui fuit les responsabilités.",
+                "(Littéraire) Personnage qui manque de courage ou de caractère ; personnage qui fuit les responsabilités."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Sens 1: Qui a l'âme faible et timide.",
+                "adj. Sens 2: Qui annonce de la pusillanimité."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 02, 2026**.