### PR TITLE
Add Dicolink word of the day for May 04, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-04.json
+++ b/data/dicolink_word_of_the_day_2026-05-04.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "Nycthémère",
+    "date": "May 04, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Unité physiologique de temps d'une durée de 24 heures, comportant une nuit et un jour, une période de sommeil et une période de veille."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Période de vingt-quatre heures correspondant à la succession d’une nuit et d’un jour (dans les régions non polaires).",
+                "n.  (Biologie) Cycle biologique de vingt-quatre heures correspondant à une nuit et jour."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 04, 2026**.