### PR TITLE
Add Dicolink word of the day for May 05, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-05.json
+++ b/data/dicolink_word_of_the_day_2026-05-05.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Pâmoison",
+    "date": "May 05, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. État de quelqu'un qui se pâme, qui s'évanouit, qui défaille (parfois ironique). : Tomber en pâmoison."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Action de se pâmer, évanouissement, syncope.",
+                "n.  (Figuré) État de bien-être que l'on ressent d'une sensation ou d'une émotion intense."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Action de se pâmer, évanouissement, syncope.",
+                "(Figuré) État de bien-être que l’on ressent d’une sensation ou d’une émotion intense."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 05, 2026**.