### PR TITLE
Add Dicolink word of the day for May 08, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-08.json
+++ b/data/dicolink_word_of_the_day_2026-05-08.json
@@ -1,0 +1,34 @@
+{
+    "word_of_the_day": "Fainéant",
+    "date": "May 08, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj.n. Qui ne fait rien, qui ne veut pas travailler."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui évite l'effort ou le travail, par paresse.",
+                "n.  Celui, celle qui ne veut rien faire."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Sens 1: Qui ne fait rien, qui ne veut point travailler. Écolier, ouvrier fainéant. Les rois fainéants, rois de la première race, qui abandonnèrent le pouvoir aux maires du palais.",
+                "adj. Sens 2:  Substantivement.:  Celui, celle qui n'aime point le travail, qui vit dans la paresse. C'est un grand fainéant, une grande fainéante."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui évite l’effort ou le travail, par paresse.",
+                "Celui, celle qui ne veut rien faire."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 08, 2026**.