### PR TITLE
Add Dicolink word of the day for May 11, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-11.json
+++ b/data/dicolink_word_of_the_day_2026-05-11.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Sternutation",
+    "date": "May 11, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Action d'éternuer, éternuement."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Médecine) (Vieilli) Éternuement."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 11, 2026**.