### PR TITLE
Add Dicolink word of the day for May 12, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-12.json
+++ b/data/dicolink_word_of_the_day_2026-05-12.json
@@ -1,0 +1,28 @@
+{
+    "word_of_the_day": "Caviarder",
+    "date": "May 12, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Ancien. Recouvrir d'un enduit noir, pour rendre illisible un passage d'un texte interdit par la censure.",
+                "v. tr. Censurer en biffant les passages d'un texte, en supprimant une partie d'une publication. (Par extension, fait de dissimuler une partie des éléments d'une annonce [nom du produit, de la marque] pour en tester la reconnaissance.)"
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Recouvrir d’un enduit noir, de façon à cacher aux yeux du lecteur un passage d’un livre ou d’un journal qui déplaît à la censure.",
+                "v.  (Par extension) Expurger un passage d’une publication en le supprimant ; censurer."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Recouvrir d’un enduit noir, de façon à cacher aux yeux du lecteur un passage d’un livre ou d’un journal qui déplaît à la censure.",
+                "(Par extension) Expurger un passage d’une publication en le supprimant ; censurer."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 12, 2026**.