### PR TITLE
Add Dicolink word of the day for May 14, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-14.json
+++ b/data/dicolink_word_of_the_day_2026-05-14.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Lénifier",
+    "date": "May 14, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Amollir quelqu'un, lui ôter de la vigueur, de l'énergie : Climat qui vous lénifie.",
+                "v. tr. Calmer, apaiser une peine morale : Ses paroles d'encouragement le lénifiaient."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  (Médecine) Adoucir au moyen d’un lénitif."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Médecine) Adoucir au moyen d’un lénitif.",
+                "(Phonétique) Altération allophonique d'un phonème, qui est prononcé plus doucement."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 14, 2026**.