### PR TITLE
Add Dicolink word of the day for May 15, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-15.json
+++ b/data/dicolink_word_of_the_day_2026-05-15.json
@@ -1,0 +1,31 @@
+{
+    "word_of_the_day": "Balancine",
+    "date": "May 15, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Sur un voilier, bras qui, de la partie supérieure du mât, soutient l'extrémité libre d'un espar."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Marine) (Vieilli) Cordage qui soutient une vergue par ses deux extrémités ou par une seule et qui sert à la tenir suspendue horizontalement ou à l’incliner d’un côté ou de l’autre.",
+                "n.  (Marine) Cordage permettant de régler la hauteur d'un espar sur un voilier. (En particulier) Corde qui soutient le gui."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Marine) (Vieilli) Cordage qui soutient une vergue par ses deux extrémités ou par une seule et qui sert à la tenir suspendue horizontalement ou à l’incliner d’un côté ou de l’autre.",
+                "(Marine) Cordage permettant de régler la hauteur d'un espar sur un voilier.",
+                "",
+                "(Aéronautique) (Vieilli): Nœud de balancine: Point de réunion des cordes intérieures de la suspension d’une nacelle de ballon, surtout de ballon captif.",
+                "(Équitation) Seconde sangle sur la selle d'amazone qui relie l’avant du côté gauche et l’arrière du côté droit pour éviter que la selle ne tourne.",
+                "(Québec) (Familier) (Populaire) Balançoire."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 15, 2026**.