### PR TITLE
Add Dicolink word of the day for May 16, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-16.json
+++ b/data/dicolink_word_of_the_day_2026-05-16.json
@@ -1,0 +1,21 @@
+{
+    "word_of_the_day": "Ondee",
+    "date": "May 16, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui forme, présente des sinuosités.",
+                "adj. Se dit d'un bois dont le fil présente de légères ondulations régulières, anomalie appréciée pour le tranchage.",
+                "adj. Se dit d'une pièce héraldique aux bords découpés en sinuosités alternativement concaves et convexes."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Pluie qui vient tout à coup et qui ne dure pas longtemps."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 16, 2026**.