### PR TITLE
Add Dicolink word of the day for May 17, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-17.json
+++ b/data/dicolink_word_of_the_day_2026-05-17.json
@@ -1,0 +1,29 @@
+{
+    "word_of_the_day": "Canular",
+    "date": "May 17, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Familier. Action, propos qui a pour but d'abuser de la crédulité de quelqu'un ; mystification, fausse nouvelle, farce."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Argot) (Désuet) Bizutage.",
+                "n.  Mystification humoristique perpétrée dans l’intention de tromper ou de faire réagir celui qui en est la cible. Il fait rire aux dépens de ceux qui l’ont cru.",
+                "n.  (Internet) Information fausse transmise souvent par messagerie électronique et incitant les destinataires abusés à effectuer des opérations ou à prendre des initiatives inutiles, voire dommageables."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Argot) (Désuet) Bizutage.",
+                "Mystification humoristique perpétrée dans l’intention de tromper ou de faire réagir celui qui en est la cible. Il fait rire aux dépens de ceux qui l’ont cru.",
+                "(Internet) Information fausse transmise souvent par messagerie électronique et incitant les destinataires abusés à effectuer des opérations ou à prendre des initiatives inutiles, voire dommageables."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 17, 2026**.