### PR TITLE
Add Dicolink word of the day for May 18, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-18.json
+++ b/data/dicolink_word_of_the_day_2026-05-18.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Tabouer",
+    "date": "May 18, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Déclarer tabou."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "v. tr. Déclarer tabou."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Déclarer tabou."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 18, 2026**.