### PR TITLE
Add Dicolink word of the day for May 19, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-19.json
+++ b/data/dicolink_word_of_the_day_2026-05-19.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Conventicule",
+    "date": "May 19, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Petite assemblée en général secrète et illicite."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Petite assemblée en général secrète et illicite."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 19, 2026**.