### PR TITLE
Add Dicolink word of the day for May 20, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-20.json
+++ b/data/dicolink_word_of_the_day_2026-05-20.json
@@ -1,0 +1,31 @@
+{
+    "word_of_the_day": "Musarder",
+    "date": "May 20, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. intr. Passer son temps à flâner."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Flâner, perdre son temps à des riens."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Terme populaire. Faire le musard."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Passer du temps à rêvasser, flâner, consacrer du temps à des riens."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 20, 2026**.