### PR TITLE
Add Dicolink word of the day for May 21, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-21.json
+++ b/data/dicolink_word_of_the_day_2026-05-21.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Rubicond",
+    "date": "May 21, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Se dit d'un visage très rouge de peau, de quelqu'un qui a un tel visage."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Très rouge de peau, principalement concernant le visage.",
+                "n.  Personne qui a le visage rouge."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Très rouge de peau, principalement concernant le visage.",
+                "Personne qui a le visage rouge."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 21, 2026**.