### PR TITLE
Add Dicolink word of the day for May 22, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-22.json
+++ b/data/dicolink_word_of_the_day_2026-05-22.json
@@ -1,0 +1,32 @@
+{
+    "word_of_the_day": "Doctement",
+    "date": "May 22, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adv. Littéraire. D'une façon pédantesque : Prouver doctement les vérités les plus banales."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "D’une manière docte."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adv. Sens 1: D'une manière savante, habile. Traiter doctement une matière.  Avoir le pouvoir prochain de voir, lui dis-je, c'est avoir bonne vue, et être en plein jour, car qui aurait bonne vue dans l'obscurité n'aurait pas le pouvoir prochain de voir, selon vous, puisque la lumière lui manquerait ; sans quoi on ne voit point.",
+                "adv. Sens 2:  Ironiquement, avec pédanterie. Il nous a prouvé doctement les vérités les plus triviales."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "D’une manière docte."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 22, 2026**.