### PR TITLE
Add Dicolink word of the day for May 24, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-24.json
+++ b/data/dicolink_word_of_the_day_2026-05-24.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Brouillamini",
+    "date": "May 24, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Familier et vieux. Complication, confusion inextricable ; embrouillamini."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Familier) Désordre, brouillerie, confusion."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Familier) Désordre, brouillerie, confusion."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 24, 2026**.