### PR TITLE
Add Dicolink word of the day for May 25, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-25.json
+++ b/data/dicolink_word_of_the_day_2026-05-25.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Misonéisme",
+    "date": "May 25, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Aversion pour tout ce qui est nouveau, pour tout changement."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Attitude qui consiste à rejeter toute innovation, tout changement."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 25, 2026**.