### PR TITLE
Add Dicolink word of the day for May 28, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-28.json
+++ b/data/dicolink_word_of_the_day_2026-05-28.json
@@ -1,0 +1,21 @@
+{
+    "word_of_the_day": "Sycophante",
+    "date": "May 28, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. À Athènes et dans quelques autres cités, dénonciateur professionnel.",
+                "n.m. Littéraire. Calomniateur, délateur, mouchard."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Antiquité) Dans l’Athènes antique, délateur professionnel, Athénien mettant en accusation ses concitoyens devant le tribunal populaire de l’Héliée en vue de s’enrichir.",
+                "n.  (Par extension) (Péjoratif) Fourbe, menteur, délateur."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 28, 2026**.