### PR TITLE
Add Dicolink word of the day for May 29, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-29.json
+++ b/data/dicolink_word_of_the_day_2026-05-29.json
@@ -1,0 +1,13 @@
+{
+    "word_of_the_day": "Opératique",
+    "date": "May 29, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui concerne l'opéra ; lyrique."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 29, 2026**.