### PR TITLE
Add Dicolink word of the day for May 30, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-30.json
+++ b/data/dicolink_word_of_the_day_2026-05-30.json
@@ -1,0 +1,32 @@
+{
+    "word_of_the_day": "Cosmogonie",
+    "date": "May 30, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Science de la formation des objets célestes (planètes, étoiles, galaxies, etc.).",
+                "n.f. Partie des mythologies qui racontent la naissance du monde et des hommes."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Système sur la formation de l’univers."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Description hypothétique de la manière dont l'univers ou un monde en particulier a été formé. Idée que se firent de l'origine du monde les anciens poëtes et les anciens sages de la Grèce. Cosmogonie de Laplace, hypothèse par laquelle ce célèbre astronome explique la formation des planètes et des satellites de notre soleil, en supposant que ce sont des parcelles qui, par l'effet d'un refroidissement progressif, se sont détachées du soleil s'étendant dans un état primitif jusqu'à la limite des dernières planètes."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Système décrivant la formation de l’univers."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 30, 2026**.