### PR TITLE
Add Dicolink word of the day for May 31, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-05-31.json
+++ b/data/dicolink_word_of_the_day_2026-05-31.json
@@ -1,0 +1,13 @@
+{
+    "word_of_the_day": "Virelangue",
+    "date": "May 31, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Groupe de mots difficiles à articuler, assemblés dans un but ludique ou pour servir d'exercice d'élocution : Répétez ce virelangue : « Il reste treize fraises fraîches. »."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **May 31, 2026**.