### PR TITLE
Add Dicolink word of the day for June 01, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-01.json
+++ b/data/dicolink_word_of_the_day_2026-06-01.json
@@ -1,0 +1,35 @@
+{
+    "word_of_the_day": "Aspérité",
+    "date": "June 01, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Inégalité, rugosité, saillie qui donne de la rudesse à une surface : Les aspérités du sol, d'un rocher.",
+                "n.f. Littéraire. Rudesse désagréable : Sa voix avait une certaine aspérité."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Qualité de ce qui est raboteux, inégal.",
+                "n.  (Figuré) Manque de douceur, d'harmonie."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1: État de ce qui est âpre, raboteux. L'aspérité d'une pierre, d'une écaille d'huître, d'un chemin.",
+                "Sens 2:  Fig. L'aspérité du caractère. Les aspérités du style, tout ce que le style a de rude dans la forme."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qualité de ce qui est raboteux, inégal.",
+                "(Figuré) Manque de douceur, d'harmonie."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 01, 2026**.