### PR TITLE
Add Dicolink word of the day for June 02, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-02.json
+++ b/data/dicolink_word_of_the_day_2026-06-02.json
@@ -1,0 +1,13 @@
+{
+    "word_of_the_day": "Galetteux",
+    "date": "June 02, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Vieux. Qui a de la galette, riche."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 02, 2026**.