### PR TITLE
Add Dicolink word of the day for June 03, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-03.json
+++ b/data/dicolink_word_of_the_day_2026-06-03.json
@@ -1,0 +1,30 @@
+{
+    "word_of_the_day": "Palabrer",
+    "date": "June 03, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. intr. Tenir des discussions interminables et sans résultat.",
+                "v. intr. En Afrique, se plaindre, demander justice.",
+                "v. intr. En Afrique, se disputer, se quereller.",
+                "v. intr. En Afrique, marchander."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Tenir un ou une palabre.",
+                "v.  (Par extension) Discuter sans fin, inutilement."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Tenir un ou une palabre.",
+                "(Par extension) Discuter sans fin, inutilement."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 03, 2026**.