### PR TITLE
Add Dicolink word of the day for June 06, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-06.json
+++ b/data/dicolink_word_of_the_day_2026-06-06.json
@@ -1,0 +1,37 @@
+{
+    "word_of_the_day": "Chemineau",
+    "date": "June 06, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Vieux. Vagabond, mendiant errant dans les campagnes."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Vieilli) (Désuet) Ouvrier qui parcourt les campagnes.",
+                "n.  (Vieilli) (Péjoratif) Vagabond, rôdeur, qui vit de petites besognes, d’aumônes ou de larcins."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Cheminée portative."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Vieilli) (Désuet) Ouvrier qui parcourt les campagnes.",
+                "(Vieilli) (Péjoratif) Vagabond, rôdeur, qui vit de petites besognes, d’aumônes ou de larcins.",
+                "Autre graphie de cheminot.",
+                "Cheminée portative en terre cuite.",
+                "(Cuisine)(Ouest de la France) Gâteau à pâte lourde, compacte.",
+                "(Rouen) Petit pain en forme de turban, qui autrefois était mangé durant le carême avec du beurre. Genre d'échaudé. (Note: dans Madame Bovary, Flaubert parle d'aller manger des cheminots à Rouen pour la fête des Rois)"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 06, 2026**.