### PR TITLE
Add Dicolink word of the day for June 07, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-07.json
+++ b/data/dicolink_word_of_the_day_2026-06-07.json
@@ -1,0 +1,32 @@
+{
+    "word_of_the_day": "Idoine",
+    "date": "June 07, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Familier et ironique. Qui convient exactement à la situation : C'est la solution idoine."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui est propre ou approprié à quelque chose, qui convient parfaitement à une situation. (Droit) Qui est propre à quelque chose."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Propre à quelque chose. Il est vieux."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui est propre ou approprié à quelque chose, qui convient parfaitement à une situation.",
+                "(Droit) Qui est propre à quelque chose."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 07, 2026**.