### PR TITLE
Add Dicolink word of the day for June 08, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-08.json
+++ b/data/dicolink_word_of_the_day_2026-06-08.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "éréthisme",
+    "date": "June 08, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Éréthisme cardio-vasculaire, état du cœur et des vaisseaux artériels animés de battements violents (après un effort physique ou une forte émotion ou au cours de certaines maladies)."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Médecine) Augmentation morbide de l’activité d’un organe.",
+                "n.  (Figuré) Passion à l’état d’exaltation maladive."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 08, 2026**.