### PR TITLE
Add Dicolink word of the day for June 09, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-09.json
+++ b/data/dicolink_word_of_the_day_2026-06-09.json
@@ -1,0 +1,38 @@
+{
+    "word_of_the_day": "Abâtardir",
+    "date": "June 09, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Faire perdre à un être vivant ses qualités originelles ; avilir, faire dégénérer.",
+                "v. tr. Faire perdre à quelque chose, de sa force, de sa vigueur, de sa valeur en l'altérant : Abâtardir un art."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  bâtardiser",
+                "v.  Dégénérer.",
+                "v.  s’altérer",
+                "v.  dégénérer"
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "v. tr. Sens 1: Faire dégénérer, au propre et au figuré. La mauvaise culture abâtardit les plantes. Ils ne voyaient là que des moyens d'abâtardir les courages.",
+                "v. tr. Sens 2: S'abâtardir, v. réfl.:  Dégénérer. Les arbres fruitiers s'abâtardissent si on ne les soigne constamment. S'abâtardir dans l'oisiveté."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Altérer de façon à faire dégénérer par un mélange génétique.",
+                "(Figuré) Dégrader.",
+                "(Pronominal) Dégénérer."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 09, 2026**.