### PR TITLE
Add Dicolink word of the day for June 11, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-11.json
+++ b/data/dicolink_word_of_the_day_2026-06-11.json
@@ -1,0 +1,32 @@
+{
+    "word_of_the_day": "Vésanie",
+    "date": "June 11, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Littéraire. Dérèglement d'esprit ; folie."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Vieilli) (Médecine) Nom générique sous lequel on comprend les différentes sortes d’aliénation mentale."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Terme de médecine. Nom générique des différentes espèces d'aliénation mentale."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Vieilli) (Médecine) Nom générique sous lequel on comprend les différentes sortes d’aliénation mentale.",
+                "(Par hyperbole) Propos ou idée dont on souligne l'aspect absurde ou délirant."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 11, 2026**.