### PR TITLE
Add Dicolink word of the day for June 12, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-12.json
+++ b/data/dicolink_word_of_the_day_2026-06-12.json
@@ -1,0 +1,32 @@
+{
+    "word_of_the_day": "Amphigourique",
+    "date": "June 12, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Se dit d'un style, d'un écrivain embrouillé et obscur."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui a le caractère de l’amphigouri."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Qui n'a ni ordre ni sens."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui a le caractère de l’amphigouri, figure de rhétorique qui consiste à écrire un discours ou un texte de manière volontairement burlesque, obscure ou inintelligible.",
+                "(Par extension) Qualifie un écrit ou un discours dont les phrases, contre l’intention de l’auteur, ne présentent que des idées sans suite et n’ont aucun sens raisonnable."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 12, 2026**.