### PR TITLE
Add Dicolink word of the day for June 13, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-13.json
+++ b/data/dicolink_word_of_the_day_2026-06-13.json
@@ -1,0 +1,34 @@
+{
+    "word_of_the_day": "Abhorrer",
+    "date": "June 13, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Littéraire. Éprouver de l'aversion pour quelque chose ou quelqu'un ; détester, exécrer : Abhorrer le mensonge."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Avoir en horreur."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "v. tr. Sens 1: Éprouver de l'horreur pour, repousser avec horreur. Abhorrer quelqu'un. Se faire abhorrer de quelqu'un. Il abhorre la cruauté. Abhorrer le nom de roi.",
+                "v. tr. Sens 2: S'abhorrer, v. réfl.:",
+                "v. tr. Sens 3: Se haïr réciproquement. Ces deux hommes s'abhorrent.",
+                "v. tr. Sens 4: Se haïr soi-même."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Avoir en horreur."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 13, 2026**.