### PR TITLE
Add Dicolink word of the day for June 14, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-14.json
+++ b/data/dicolink_word_of_the_day_2026-06-14.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Amphigouri",
+    "date": "June 14, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Littéraire. Langage ou écrit obscur, embrouillé, peu intelligible."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Figure de rhétorique qui consiste à écrire un discours ou un texte de manière volontairement burlesque, obscure ou inintelligible.",
+                "n.  (Par extension) Propos désordonné dont les phrases mal construites et le vocabulaire incertain, n’aboutissent à aucun sens satisfaisant. Discours confus, embrouillé et obscur."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Rhétorique) Figure de rhétorique qui consiste à écrire un discours ou un texte de manière volontairement burlesque, obscure ou inintelligible.",
+                "(Par extension) Propos désordonné dont les phrases mal construites et le vocabulaire incertain n’aboutissent à aucun sens satisfaisant. Discours confus, embrouillé et obscur."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 14, 2026**.