### PR TITLE
Add Dicolink word of the day for June 15, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-15.json
+++ b/data/dicolink_word_of_the_day_2026-06-15.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Cailletage",
+    "date": "June 15, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Familier) (Péjoratif) Bavardage de caillettes."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Familier) (Péjoratif) Bavardage de caillettes."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 15, 2026**.