### PR TITLE
Add Dicolink word of the day for June 16, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-16.json
+++ b/data/dicolink_word_of_the_day_2026-06-16.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Nitescence",
+    "date": "June 16, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Littéraire Clarté ; lueur."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Clarté, lueur."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 16, 2026**.