### PR TITLE
Add Dicolink word of the day for June 17, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-17.json
+++ b/data/dicolink_word_of_the_day_2026-06-17.json
@@ -1,0 +1,36 @@
+{
+    "word_of_the_day": "Cacophonie",
+    "date": "June 17, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Rencontre de mots, de syllabes, de sons désagréables ou ridicules.",
+                "n.f. Effet désagréable produit par des instruments qui jouent, des voix qui chantent sans accord, sans harmonie."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Rencontre de syllabes ou de mots qui dans le langage forment un son désagréable à l’oreille.",
+                "n.  Désigne des voix et des instruments de musique qui chantent et qui jouent sans être accordés."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1: Vice d'élocution qui consiste en un son désagréable, produit par la rencontre de deux lettres ou de deux syllabes, ou par la répétition trop fréquente des mêmes lettres ou des mêmes syllabes. En l'en entendant parler fait une cacophonie insupportable.",
+                "Sens 2:  Terme de musique. Assemblage discordant de plusieurs sons ou de sons discordants. Jamais on n'entendit pareille cacophonie."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Rhétorique) Rencontre de syllabes ou de mots qui dans le langage forment un son désagréable à l’oreille.",
+                "(Musique) Désigne des voix et des instruments de musique qui chantent et qui jouent sans être accordés.",
+                "(Par extension) (Figuré) Désigne des situations où les intervenants prennent des positions ou émettent des jugements sans être complétement en accord."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 17, 2026**.