### PR TITLE
Add Dicolink word of the day for June 18, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-18.json
+++ b/data/dicolink_word_of_the_day_2026-06-18.json
@@ -1,0 +1,31 @@
+{
+    "word_of_the_day": "Cascatelle",
+    "date": "June 18, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Littéraire. Petite cascade."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Petite cascade."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Petite cascade.",
+                "(Figuré) Quelque chose qui ressemble à une cascade (suivant le contexte).",
+                "Première personne du singulier de l’indicatif présent de cascateller.",
+                "Troisième personne du singulier de l’indicatif présent de cascateller.",
+                "Première personne du singulier du subjonctif présent de cascateller.",
+                "Troisième personne du singulier du subjonctif présent de cascateller.",
+                "Deuxième personne du singulier de l’impératif présent de cascateller."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 18, 2026**.