### PR TITLE
Add Dicolink word of the day for June 19, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-19.json
+++ b/data/dicolink_word_of_the_day_2026-06-19.json
@@ -1,0 +1,13 @@
+{
+    "word_of_the_day": "Prepotence",
+    "date": "June 19, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Pouvoir supérieur, supériorité de puissance avec une idée d'abus, d'absolutisme."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 19, 2026**.