### PR TITLE
Add Dicolink word of the day for June 20, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-20.json
+++ b/data/dicolink_word_of_the_day_2026-06-20.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "Stipendier",
+    "date": "June 20, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Littéraire. Payer quelqu'un pour accomplir une tâche méprisable ou criminelle, acheter sa complicité : Stipendier des agents provocateurs."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  (Vieilli) Avoir quelqu’un à sa solde.",
+                "v.  (En particulier) Employer (des gens) à l’exécution de mauvais desseins."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 20, 2026**.