### PR TITLE
Add Dicolink word of the day for June 21, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-21.json
+++ b/data/dicolink_word_of_the_day_2026-06-21.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Prosélytisme",
+    "date": "June 21, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Zèle ardent pour recruter des adeptes, pour tenter d'imposer ses idées."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Souvent péjoratif) Zèle ardent pour recruter des adeptes, pour tenter d’imposer ses idées."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Zèle de faire des prosélytes.  Il se dit le plus souvent en mauvaise part."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 21, 2026**.