### PR TITLE
Add Dicolink word of the day for June 22, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-22.json
+++ b/data/dicolink_word_of_the_day_2026-06-22.json
@@ -1,0 +1,31 @@
+{
+    "word_of_the_day": "Citrin",
+    "date": "June 22, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. D'une couleur jaune citron."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui est de couleur de citron."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Qui est de la couleur du citron. Couleur citrine. S. m.:  Le citrin."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui est de couleur de citron."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 22, 2026**.