### PR TITLE
Add Dicolink word of the day for June 23, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-23.json
+++ b/data/dicolink_word_of_the_day_2026-06-23.json
@@ -1,0 +1,13 @@
+{
+    "word_of_the_day": "Abietin",
+    "date": "June 23, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Extrêmement rare) Relatif aux sapins."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 23, 2026**.