### PR TITLE
Add Dicolink word of the day for June 24, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-24.json
+++ b/data/dicolink_word_of_the_day_2026-06-24.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Irénisme",
+    "date": "June 24, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Attitude de compréhension et de charité, adoptée entre chrétiens de confessions différentes pour l'exposé et l'étude des problèmes qui les séparent."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Religion) Attitude visant à favoriser la bonne entente entre les religions. Le mot s'est d'abord employé dans un contexte chrétien.",
+                "n.  Attitude de celui recherchant la paix et la concorde.",
+                "n.  (Philosophie) Attitude de celui qui fait de la concorde l’objectif politique premier."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Recherche de la paix et de la concorde."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 24, 2026**.