### PR TITLE
Add Dicolink word of the day for June 26, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-26.json
+++ b/data/dicolink_word_of_the_day_2026-06-26.json
@@ -1,0 +1,26 @@
+{
+    "word_of_the_day": "Décalvant",
+    "date": "June 26, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui rend chauve."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui rend chauve."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui rend chauve.",
+                "Participe présent de décalver."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 26, 2026**.