### PR TITLE
Add Dicolink word of the day for June 27, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-27.json
+++ b/data/dicolink_word_of_the_day_2026-06-27.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Altier",
+    "date": "June 27, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Qui manifeste un dédain méprisant ; hautain, orgueilleux."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui est d’une fierté impérieuse.",
+                "Qui marque, dénote, annonce une fierté impérieuse."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui est d’une fierté impérieuse.",
+                "Qui marque, dénote, annonce une fierté impérieuse."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 27, 2026**.