### PR TITLE
Add Dicolink word of the day for June 28, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-28.json
+++ b/data/dicolink_word_of_the_day_2026-06-28.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Angélisme",
+    "date": "June 28, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Désir de pureté extrême et refus d'admettre certaines réalités charnelles, sociales, matérielles."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Généralement dépréciatif) Attitude qui ignore les contingences ou les réalités humaines matérielles, morales, sociologiques etc. par manque de réalisme ou d’esprit pratique. Tendance à présenter ou à voir les choses ou les gens sous un jour optimiste. ? voir candeur, crédulité, idéalisation, idéalisme, irréalisme, naïveté, utopisme.",
+                "n.  Tendance à privilégier le spirituel par rapport au charnel par désir de chasteté, de pureté. ? voir pruderie, puritanisme",
+                "n.  (Plus rare) Qualité de ce qui est angélique."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Plus rare) Qualité de ce qui est angélique."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 28, 2026**.