### PR TITLE
Add Dicolink word of the day for June 29, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-06-29.json
+++ b/data/dicolink_word_of_the_day_2026-06-29.json
@@ -1,0 +1,36 @@
+{
+    "word_of_the_day": "étique",
+    "date": "June 29, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. D'apparence chétive ; rachitique : Des arbustes étiques.",
+                "adj. Littéraire. Décharné, d'une extrême maigreur : Cheval étique."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Savant) Extrêmement maigre ; atteint d’étisie.",
+                "(Figuré) Mesquin, pauvre, insuffisant.",
+                "n.  Personne extrêmement maigre ; personne atteinte d’étisie."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Deuxième personne du singulier de l’impératif présent de étiquer.",
+                "Troisième personne du singulier du subjonctif présent de étiquer.",
+                "Première personne du singulier du subjonctif présent de étiquer.",
+                "Troisième personne du singulier de l’indicatif présent de étiquer.",
+                "Première personne du singulier de l’indicatif présent de étiquer.",
+                "Personne extrêmement maigre ; personne atteinte d’étisie.",
+                "(Anthropologie) Dont le point de vue résulte de l’analyse scientifique propre à un observateur ; relatif au discours savant d’une société étudiée.",
+                "(Figuré) Mesquin, pauvre, insuffisant.",
+                "(Savant) Extrêmement maigre ; atteint d’étisie."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **June 29, 2026**.