### PR TITLE
Add Dicolink word of the day for July 01, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-01.json
+++ b/data/dicolink_word_of_the_day_2026-07-01.json
@@ -1,0 +1,36 @@
+{
+    "word_of_the_day": "Dirimant",
+    "date": "July 01, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Se dit des empêchements qui entraînent la nullité d'une union contractée malgré ces empêchements.",
+                "adj. Littéraire. Se dit d'un empêchement radical, formel, absolu : Une objection dirimante."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Droit) Qui emporte la nullité d’un acte et particulièrement d’un mariage.",
+                "Qui détruit un raisonnement."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj.  Terme de droit. Qui rend nul. Empêchement dirimant, empêchement qui emporte la nullité d'un mariage.  Par extension."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Droit) Qui entraine la nullité d’un acte, particulièrement d’un mariage.",
+                "(Par extension) Contraignant, qui ne laisse aucune possibilité de recours.",
+                "Qui détruit un raisonnement.",
+                "Participe présent du verbe dirimer."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 01, 2026**.