### PR TITLE
Add Dicolink word of the day for July 02, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-02.json
+++ b/data/dicolink_word_of_the_day_2026-07-02.json
@@ -1,0 +1,33 @@
+{
+    "word_of_the_day": "Bélître",
+    "date": "July 02, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Vieux. Homme de rien, coquin."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Variante orthographique de bélître."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Homme de rien, homme sans valeur. C'est un franc bélître."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Péjoratif) (Vieilli) Homme de rien ; personne négligeable.",
+                "(Vieilli) Coquin.",
+                "(Désuet) Gueux ; mendiant."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 02, 2026**.