### PR TITLE
Add Dicolink word of the day for July 03, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-03.json
+++ b/data/dicolink_word_of_the_day_2026-07-03.json
@@ -1,0 +1,31 @@
+{
+    "word_of_the_day": "Gangue",
+    "date": "July 03, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Partie non exploitable d'un filon minéralisé.",
+                "n.f. Matière sans valeur entourant une pierre précieuse dans son gisement naturel.",
+                "n.f. Plus généralement, ensemble des éléments minéraux sans valeur associés au minéral utile dans un minerai.",
+                "n.f. Tissu scléreux (dur), d'origine inflammatoire ou tumorale, qui enveloppe un organe ou ses éléments constitutifs."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Minéralogie) Substance pierreuse ou autre qui enveloppe les minéraux dans le sein de la terre.",
+                "n.  (Anatomie) Substance amorphe enveloppant un élément anatomique. Matière visqueuse qui permet de conglomérer les œufs de certains poissons comme le brochet."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Minéralogie) Substance pierreuse ou autre qui enveloppe les minéraux dans le sein de la terre.",
+                "(Anatomie) Substance amorphe enveloppant un élément anatomique.",
+                "(Figuré) Ensemble d'idées ou de sentiments confus, désagréables ou malsains comparables où se trouve ou pourrait se trouver une autre idée ou un autre état précieux."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 03, 2026**.