### PR TITLE
Add Dicolink word of the day for July 04, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-04.json
+++ b/data/dicolink_word_of_the_day_2026-07-04.json
@@ -1,0 +1,33 @@
+{
+    "word_of_the_day": "Laïus",
+    "date": "July 04, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Familier. Discours, souvent long, creux ou emphatique."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Souvent péjoratif) Long discours, exposé, long développement verbeux et creux, baratin.",
+                "n.  (Souvent péjoratif) Exposé un peu convenu, qui semble manquer de sincérité ou de vérité. Note : Souvent accompagné de l'adjectif petit."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Un discours, dans l'argot des jeunes gens de l'École polytechnique. Piquer un laïus, prononcer un discours."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Péjoratif) Long discours, exposé, long développement verbeux et creux, baratin.",
+                "(Péjoratif) Exposé un peu convenu, qui semble manquer de sincérité ou de vérité. Note :  Souvent accompagné de l'adjectif petit."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 04, 2026**.