### PR TITLE
Add Dicolink word of the day for July 06, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-06.json
+++ b/data/dicolink_word_of_the_day_2026-07-06.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Annelure",
+    "date": "July 06, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Rare) Frisure de cheveux par boucles ou anneaux."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Frisure des cheveux par anneaux. Peu usité."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Rare) Frisure de cheveux par boucles ou anneaux."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 06, 2026**.