### PR TITLE
Add Dicolink word of the day for July 08, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-08.json
+++ b/data/dicolink_word_of_the_day_2026-07-08.json
@@ -1,0 +1,21 @@
+{
+    "word_of_the_day": "Inextinguible",
+    "date": "July 08, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Qu'il est impossible d'éteindre : Feu inextinguible.",
+                "adj. Qu'on ne peut apaiser, arrêter : Soif inextinguible. Rire inextinguible."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui ne peut s’éteindre.",
+                "(Figuré) Qui ne s’éteint pas, ne peut disparaître, s’oublier, cesser, se réprimer."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 08, 2026**.