### PR TITLE
Add Dicolink word of the day for July 09, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-09.json
+++ b/data/dicolink_word_of_the_day_2026-07-09.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Calembredaine",
+    "date": "July 09, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Histoire absurde, extravagante sottise."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Bourde, vains propos, faux-fuyant, sornette."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Bourde, vains propos, faux-fuyant, sornette."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 09, 2026**.