### PR TITLE
Add Dicolink word of the day for July 10, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-10.json
+++ b/data/dicolink_word_of_the_day_2026-07-10.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Imperturbable",
+    "date": "July 10, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Que rien ne trouble, n'émeut, n'ébranle : Sérénité imperturbable."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Que rien ne peut troubler, ébranler, émouvoir."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Que rien ne peut troubler, ébranler, émouvoir.  Il se dit aussi des choses."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 10, 2026**.