### PR TITLE
Add Dicolink word of the day for July 11, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-11.json
+++ b/data/dicolink_word_of_the_day_2026-07-11.json
@@ -1,0 +1,32 @@
+{
+    "word_of_the_day": "Tesselle",
+    "date": "July 11, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Petit morceau de marbre, de pierre, de pâte de verre ou de céramique, matériau de base d'une mosaïque murale ou de pavement."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Fragment de pierre, de terre cuite, ou de marbre employé dans les mosaïques de pavement.",
+                "n.  Petit élément de forme régulière utilisé en marqueterie."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Fragment de pierre, de terre cuite, ou de marbre employé dans les mosaïques de pavement.",
+                "Petit élément de forme régulière utilisé en marqueterie.",
+                "Première personne du singulier de l’indicatif présent du verbe tesseller.",
+                "Troisième personne du singulier de l’indicatif présent du verbe tesseller.",
+                "Première personne du singulier du subjonctif présent du verbe tesseller.",
+                "Troisième personne du singulier du subjonctif présent du verbe tesseller.",
+                "Deuxième personne du singulier de l’impératif du verbe tesseller."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 11, 2026**.