### PR TITLE
Add Dicolink word of the day for July 13, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-13.json
+++ b/data/dicolink_word_of_the_day_2026-07-13.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Lambrusque",
+    "date": "July 13, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Vigne sauvage donnant des fruits, que l'on rencontre encore dans certaines forêts d'Europe."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Vigne sauvage qui croît dans les buissons et les bois."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 13, 2026**.