### PR TITLE
Add Dicolink word of the day for July 14, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-14.json
+++ b/data/dicolink_word_of_the_day_2026-07-14.json
@@ -1,0 +1,51 @@
+{
+    "word_of_the_day": "Nymphe",
+    "date": "July 14, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Littéraire. Jeune fille gracieuse et bien faite.",
+                "n.f. Repli membraneux de la vulve.",
+                "n.f. Forme, souvent immobile, prise par les insectes supérieurs juste avant leur éclosion sous la forme adulte ; dernière forme larvaire, active, des insectes inférieurs.",
+                "n.f. Divinité féminine de l'Antiquité gréco-romaine, personnifiant divers aspects de la nature et représentée le plus souvent sous les traits d'une jeune fille nue."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Mythologie grecque et romaine) Divinité féminine d’un rang inférieur qui hante les fleuves, les sources, les bois, les montagnes, les prairies, les mers, etc.",
+                "n.  (Poésie) Belle jeune fille ou jeune femme.",
+                "n.  (Ironique) Jeune fille ou jeune femme qui est attachée à un lieu, à un rôle, à une fonction.",
+                "n.  Stade de métamorphose d’un insecte, intermédiaire entre l’état de larve et celui d’imago.",
+                "n.  (Anglicisme) Improprement employé pour désigner la larve âgée du puceron dont les ébauches des ailes sont déjà développées.",
+                "n.  (Anatomie) pluriel Petites lèvres, replis membraneux de chaque côté de l'orifice vaginal sous les grandes lèvres de la vulve.",
+                "n.  (Zoologie) Une espèce d’insecte lépidoptère (papillon) de nuit de la famille des noctuidés (Noctuidae) dont le dos des ailes est de couleur brune avec des bandes foncées et du jaune sur les ailes postérieures."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1: Dans le polythéisme gréco-latin, divinité des fleuves, des bois, des montagnes.",
+                "Sens 2: En poésie, jeune fille belle et bien faite. C'est une nymphe. Elle a une taille de nymphe, se dit d'une jeune personne dont la taille est élégante et légère.",
+                "Sens 3:  Fig. Courtisane, femme galante.",
+                "Sens 4:  Terme d'histoire naturelle. Insecte parvenu de l'état de larve à son second état, principalement lorsque, sous cette forme, il possède la faculté de se mouvoir ; d'où il suit qu'une nymphe est une chrysalide mobile ; chrysalide se dit seulement de la nymphe des lépidoptères ; ainsi la chrysalide se change toujours en papillon, et jamais en mouche.   Fig.  Les nymphes des fourmis sont ce qu'on appelle vulgairement œufs de fourmis. Genre d'insectes voisins des hémérobes.",
+                "Sens 5:  Terme d'anatomie. Nom de deux replis membraneux chez la femme, ainsi dits parce que, voisins du méat urinaire, ils servent à conduire l'urine.",
+                "Sens 6: Nymphe de Ternate, martin-pêcheur à longs brins."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Mythologie) Divinité féminine grecque d’un rang inférieur qui hante les fleuves, les sources, les bois, les montagnes, les prairies, les mers, etc., et personnifie les forces vives de la nature.",
+                "(Poésie) Belle jeune fille ou jeune femme.",
+                "(Ironique) Jeune fille ou jeune femme attachée à un lieu, à un rôle, à une fonction.",
+                "(Entomologie) Stade de métamorphose d’un insecte, intermédiaire entre l’état de larve et celui d’imago.",
+                "(Anglicisme) (Sens non classique) Larve âgée du puceron dont les ébauches des ailes sont déjà développées.",
+                "(Anatomie) (au pluriel) Petites lèvres, replis membraneux de chaque côté de l’orifice vaginal sous les grandes lèvres de la vulve.",
+                "(Entomologie) Une espèce d’insecte lépidoptère (papillon) de nuit de la famille des noctuidés (Noctuidae) dont le dos des ailes est de couleur brune avec des bandes foncées et du jaune sur les ailes postérieures."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 14, 2026**.