### PR TITLE
Add Dicolink word of the day for July 15, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-15.json
+++ b/data/dicolink_word_of_the_day_2026-07-15.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Munificence",
+    "date": "July 15, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Littéraire. Disposition d'esprit qui porte aux grandes libéralités ; étalage de générosité, magnificence."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Disposition qui porte à faire de grandes libéralités."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Qualité qui porte à faire de grandes libéralités."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 15, 2026**.