### PR TITLE
Add Dicolink word of the day for July 16, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-16.json
+++ b/data/dicolink_word_of_the_day_2026-07-16.json
@@ -1,0 +1,13 @@
+{
+    "word_of_the_day": "Orbicole",
+    "date": "July 16, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui est susceptible de vivre sur n?importe quel point du globe."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 16, 2026**.