### PR TITLE
Add Dicolink word of the day for July 17, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-17.json
+++ b/data/dicolink_word_of_the_day_2026-07-17.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Cogiter",
+    "date": "July 17, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. intr. Familier et ironique. Penser, réfléchir à quelque chose : Qu'est-ce que tu cogites ?"
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  (Familier) Réfléchir, penser."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Familier) Réfléchir ; penser."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 17, 2026**.