### PR TITLE
Add Dicolink word of the day for July 18, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-18.json
+++ b/data/dicolink_word_of_the_day_2026-07-18.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Viveur",
+    "date": "July 18, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Vieux. Personne qui mène une vie de plaisirs. (Le féminin viveuse est rare.)"
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Vieilli) Celui qui abuse de la vie."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Vieilli) Celui qui abuse de la vie, qui sait vivre."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 18, 2026**.