### PR TITLE
Add Dicolink word of the day for July 19, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-19.json
+++ b/data/dicolink_word_of_the_day_2026-07-19.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Rimailleur",
+    "date": "July 19, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n. Familier et vieux. Auteur de mauvais vers."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Familier) (Poésie) Poète qui fait de mauvais vers."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 19, 2026**.