### PR TITLE
Add Dicolink word of the day for July 20, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-20.json
+++ b/data/dicolink_word_of_the_day_2026-07-20.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Lilial",
+    "date": "July 20, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Qui a la blancheur, la pureté du lis."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Poétique) Qui tient du lis, qui en a la pureté et la blancheur. ."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Poétique) Qui tient du lis, qui en a la pureté et la blancheur extrême."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 20, 2026**.