### PR TITLE
Add Dicolink word of the day for July 21, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-21.json
+++ b/data/dicolink_word_of_the_day_2026-07-21.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Altruisme",
+    "date": "July 21, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Souci désintéressé du bien d'autrui : Agir par altruisme."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Disposition à s’occuper d’autrui, à s’y intéresser.",
+                "n.  Sentiment d’amour instinctif ou réfléchi pour autrui."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Disposition à s’occuper d’autrui, à s’y intéresser.",
+                "Sentiment d’amour instinctif ou réfléchi pour autrui."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 21, 2026**.