### PR TITLE
Add Dicolink word of the day for July 22, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-22.json
+++ b/data/dicolink_word_of_the_day_2026-07-22.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Altérite",
+    "date": "July 22, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Formation superficielle issue de l'altération de la roche en place."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Géologie) Étape de la dégradation d'une roche, où elle forme une structure plus ou moins friable, avant son érosion complète.",
+                "n.  (Géographie) Ensemble de matériaux hétérogènes recouvrant une roche solide."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Géologie) Étape de la dégradation d'une roche, où elle forme une structure plus ou moins friable, avant son érosion complète.",
+                "(Géographie) Ensemble de matériaux hétérogènes recouvrant une roche solide."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 22, 2026**.