### PR TITLE
Add Dicolink word of the day for July 23, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-23.json
+++ b/data/dicolink_word_of_the_day_2026-07-23.json
@@ -1,0 +1,44 @@
+{
+    "word_of_the_day": "Géhenne",
+    "date": "July 23, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Littéraire. Souffrance presque intolérable ; supplice, torture.",
+                "n.f. L'enfer, dans les écrits bibliques."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Religion biblique) (Au singulier) L’enfer.",
+                "n.  (Par extension) Endroit où l’on a beaucoup à souffrir.",
+                "n.  (Par extension) Torture ; intense souffrance ; douleur intolérable.",
+                "n.  (Figuré) Souffrance physique ou morale atroce."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 2:  Fig. L'enfer, en style de l'Écriture. La géhenne du feu. Le feu de la géhenne.",
+                "Sens 1: Proprement, vallée près de Jérusalem où les Juifs brûlaient leurs fils et leurs filles en l'honneur des idoles."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Bible) (Au singulier) L’enfer.",
+                "(Par extension) Endroit où l’on a beaucoup à souffrir.",
+                "(Par extension) Torture ; intense souffrance ; douleur intolérable.",
+                "(Figuré) Souffrance physique ou morale atroce.",
+                "Première personne du singulier du présent de l’indicatif de géhenner.",
+                "Troisième personne du singulier du présent de l’indicatif de géhenner.",
+                "Première personne du singulier du présent du subjonctif de géhenner.",
+                "Troisième personne du singulier du présent du subjonctif de géhenner.",
+                "Deuxième personne du singulier de l’impératif de géhenner."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 23, 2026**.