### PR TITLE
Add Dicolink word of the day for July 25, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-25.json
+++ b/data/dicolink_word_of_the_day_2026-07-25.json
@@ -1,0 +1,32 @@
+{
+    "word_of_the_day": "Contempteur",
+    "date": "July 25, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n. Littéraire. Personne qui dénigre quelqu'un ou quelque chose : Les contempteurs des valeurs morales."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Celui qui méprise quelqu’un ou quelque chose."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1: Celui, celle qui méprise, qui a l'esprit méprisant.",
+                "Sens 2:  Adjectivement.:"
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Littéraire) Celui qui méprise quelqu’un ou quelque chose."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 25, 2026**.