### PR TITLE
Add Dicolink word of the day for July 26, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-26.json
+++ b/data/dicolink_word_of_the_day_2026-07-26.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Gnognotte",
+    "date": "July 26, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Familier. De la gnognote, se dit de quelque chose, de quelqu'un qui est sans valeur ; se dit de quelque chose qui est facile, sans difficulté, négligeable."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Variante, dans l'orthographe traditionnelle, de gnognote (orthographe rectifiée de 1990)."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Terme populaire. Chose de peu de valeur. C'est de la gnognotte."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 26, 2026**.