### PR TITLE
Add Dicolink word of the day for July 27, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-27.json
+++ b/data/dicolink_word_of_the_day_2026-07-27.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "Superfétatoire",
+    "date": "July 27, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Qui s'ajoute inutilement à quelque chose : Une explication superfétatoire."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Rare) (Sens étymologique) Qualifie la naissance d’un second enfant après le premier et dans un écart de temps qui dénote une superfécondation.",
+                "Qui est superflu, inutilement ajouté, qui vient en sus, de façon peu naturelle."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 27, 2026**.