### PR TITLE
Add Dicolink word of the day for July 28, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-28.json
+++ b/data/dicolink_word_of_the_day_2026-07-28.json
@@ -1,0 +1,26 @@
+{
+    "word_of_the_day": "Apophtegme",
+    "date": "July 28, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Parole, sentence mémorable, exprimée de façon concise et claire ; aphorisme, maxime."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Parole mémorable de quelque personne illustre ayant valeur de maxime."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Parole mémorable, maxime, adage, aphorisme.",
+                "Petit récit à vocation morale ou spirituelle, fable, parabole."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 28, 2026**.