### PR TITLE
Add Dicolink word of the day for July 29, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-29.json
+++ b/data/dicolink_word_of_the_day_2026-07-29.json
@@ -1,0 +1,26 @@
+{
+    "word_of_the_day": "Ronchon",
+    "date": "July 29, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "Familier. Personne qui ronchonne pour peu de chose, qui a l'habitude de ronchonner."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Bougon et grincheux."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Bougon et grincheux.",
+                "Personnage bougon et grincheux."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 29, 2026**.