### PR TITLE
Add Dicolink word of the day for July 30, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-30.json
+++ b/data/dicolink_word_of_the_day_2026-07-30.json
@@ -1,0 +1,34 @@
+{
+    "word_of_the_day": "Circonspect",
+    "date": "July 30, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui agit avec réflexion et prudence ou qui manifeste cela : Répondre en termes circonspects."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui prend garde à ce qu’il dit, à ce qu’il fait, en ayant égard aux circonstances, au milieu. Qui ne s'engage qu'après examen.",
+                "Qui marque de la circonspection."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Sens 1: Qui regarde autour de soi, qui prend bien garde à ce qu'il fait ou à ce qu'il dit. Être circonspect dans ses paroles, dans ses actions.    Substantivement.:",
+                "adj. Sens 2: Où il y a de la circonspection. Conduite circonspecte."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui prend garde à ce qu’il dit, à ce qu’il fait, en ayant égard aux circonstances, au milieu. Qui ne s’engage qu’après examen.",
+                "Qui marque de la circonspection."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 30, 2026**.