### PR TITLE
Add Dicolink word of the day for July 31, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-07-31.json
+++ b/data/dicolink_word_of_the_day_2026-07-31.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Quémander",
+    "date": "July 31, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Demander quelque chose à quelqu'un, le solliciter avec insistance et humilité : Quémander des secours à une organisation charitable."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Demander, solliciter quelque chose."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **July 31, 2026**.