### PR TITLE
Add Dicolink word of the day for August 02, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-02.json
+++ b/data/dicolink_word_of_the_day_2026-08-02.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "Foutraque",
+    "date": "August 02, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Familier. Fou, extravagant."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Fou et excentrique.",
+                "n.  Personne folle et excentrique."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 02, 2026**.