### PR TITLE
Add Dicolink word of the day for August 03, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-03.json
+++ b/data/dicolink_word_of_the_day_2026-08-03.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Calanque",
+    "date": "August 03, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. En Provence, crique étroite et allongée, aux parois rocheuses escarpées."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Marine) Petite baie, crique, parfois profonde et entourée de terres élevées."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Marine) Petite baie, crique, parfois profonde et entourée de terres élevées."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 03, 2026**.