### PR TITLE
Add Dicolink word of the day for August 04, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-04.json
+++ b/data/dicolink_word_of_the_day_2026-08-04.json
@@ -1,0 +1,20 @@
+{
+    "word_of_the_day": "Nautonier",
+    "date": "August 04, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n. Personne qui conduit un navire, une barque."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Vieilli) Celui, celle qui conduit un navire, une barque.",
+                "n.  (Poésie) ou (Mythologie) Charon."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 04, 2026**.