### PR TITLE
Add Dicolink word of the day for August 05, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-05.json
+++ b/data/dicolink_word_of_the_day_2026-08-05.json
@@ -1,0 +1,41 @@
+{
+    "word_of_the_day": "Harangue",
+    "date": "August 05, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Littéraire. Discours solennel prononcé devant une assemblée, une personnalité importante, des troupes, etc. : Les harangues des orateurs de la Révolution.",
+                "n.f. Familier. Discours quelconque, ou discours pompeux, ennuyeux ou moralisateur."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Discours fait à une assemblée, à un prince ou à quelque autre personne élevée en dignité.",
+                "n.  (Familier) Discours ennuyeux ; longue remontrance."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1: Discours fait à une assemblée, à un prince ou à quelque autre personne élevée en dignité.",
+                "Sens 2:  Par extension, un discours quelconque.",
+                "Sens 3:  Familièrement. Discours ennuyeux, longue remontrance. Quand aura-t-il fini sa harangue ?Voy. à DISCOURS, où la synonymie est exposée."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Discours fait à une assemblée, à un prince ou à quelque autre personne élevée en dignité.",
+                "(Familier) Discours ennuyeux ; longue remontrance.",
+                "Première personne du singulier du présent de l’indicatif de haranguer.",
+                "Troisième personne du singulier du présent de l’indicatif de haranguer.",
+                "Première personne du singulier du présent du subjonctif de haranguer.",
+                "Troisième personne du singulier du présent du subjonctif de haranguer.",
+                "Deuxième personne du singulier de l’impératif de haranguer."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 05, 2026**.