### PR TITLE
Add Dicolink word of the day for August 06, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-06.json
+++ b/data/dicolink_word_of_the_day_2026-08-06.json
@@ -1,0 +1,39 @@
+{
+    "word_of_the_day": "Bégueule",
+    "date": "August 06, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj.n. Familier. Qui témoigne d'une pruderie excessive ou affectée."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Familier) Personne d’une pruderie excessive et affectée.",
+                "n.  (Familier) Personne trop exigeante, difficile, à qui ne convient que le meilleur.",
+                "(Familier) Sottement pudibond, exagérément prude et qui se donne des airs de vertu.",
+                "(Familier) Difficile, qui fait la fine bouche, par nature.",
+                "(Par extension) Hautain, prétentieux, ignorant les autres."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Femme prude et dédaigneuse d'une façon mal plaisante.   Faire la bégueule, affecter ridiculement la vertu et la modestie.  Adjectivement: . Que cette femme est bégueule ! Il se dit d'un homme en plaisantant."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Familier) Personne d’une pruderie excessive et affectée.",
+                "(Familier) Personne trop exigeante, difficile, à qui ne convient que le meilleur.",
+                "(Familier) Sottement pudibond, exagérément prude et qui se donne des airs de vertu.",
+                "(Familier) Difficile, qui fait la fine bouche, par nature.",
+                "(Par extension) Hautain, prétentieux, ignorant les autres."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 06, 2026**.