### PR TITLE
Add Dicolink word of the day for August 07, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-07.json
+++ b/data/dicolink_word_of_the_day_2026-08-07.json
@@ -1,0 +1,31 @@
+{
+    "word_of_the_day": "Taveler",
+    "date": "August 07, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Marquer un fruit, une surface de petites taches."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Moucheter, tacheter, en parlant de la peau de certains animaux."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "v. tr. Marquer de taches, de mouchetures.Se taveler, v. réfl.:  Devenir tavelé. La peau de cet animal commence à se taveler."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Moucheter, tacheter, en parlant de la peau de certains animaux."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 07, 2026**.