### PR TITLE
Add Dicolink word of the day for August 08, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-08.json
+++ b/data/dicolink_word_of_the_day_2026-08-08.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Caboulot",
+    "date": "August 08, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Populaire et vieux. Petit café à clientèle populaire."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Cabaret de bas étage, bastringue, bistro, troquet ; bal musette, cabane, guinguette."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Cabaret de bas étage, bastringue, bistro, troquet ; bal musette, cabane, guinguette.",
+                "Loge dans une étable.",
+                "(Par extension) Endroit étroit et obscur."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 08, 2026**.