### PR TITLE
Add Dicolink word of the day for August 09, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-09.json
+++ b/data/dicolink_word_of_the_day_2026-08-09.json
@@ -1,0 +1,23 @@
+{
+    "word_of_the_day": "Galvaniser",
+    "date": "August 09, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Pratiquer la galvanisation (d'un tissu vivant ou d'un métal).",
+                "v. tr. Provoquer l'enthousiasme de quelqu'un, le plus souvent d'une manière passagère : Galvaniser un auditoire."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Électriser au moyen de la pile galvanique ou pile de Volta.",
+                "v.  (En particulier) Mettre les muscles en mouvement, soit pendant la vie, soit peu de temps après la mort, au moyen de la pile galvanique.",
+                "v.  Plonger un métal dans un bain de zinc fondu pour le recouvrir d’une couche de ce métal et le préserver de l’oxydation.",
+                "v.  (Figuré) Donner un encouragement, une impulsion ; stimuler."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 09, 2026**.