### PR TITLE
Add Dicolink word of the day for August 10, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-10.json
+++ b/data/dicolink_word_of_the_day_2026-08-10.json
@@ -1,0 +1,28 @@
+{
+    "word_of_the_day": "Présager",
+    "date": "August 10, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Littéraire. Annoncer quelque chose, en être le signe : Cet horizon rouge présage un vent très violent.",
+                "v. tr. Prévoir quelque chose : Je n'aurais jamais pu présager qu'il en arriverait à cette extrémité."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  Indiquer ou annoncer une chose à venir.",
+                "v.  Conjecturer ce qui doit arriver dans l’avenir."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Indiquer ou annoncer une chose à venir.",
+                "Conjecturer ce qui doit arriver dans l’avenir."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 10, 2026**.