### PR TITLE
Add Dicolink word of the day for August 11, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-11.json
+++ b/data/dicolink_word_of_the_day_2026-08-11.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Rebuffade",
+    "date": "August 11, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Refus brutal ou désagréable : Essuyer une rebuffade."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Attitude de refus brutal d’une demande ou d’une attente."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 11, 2026**.