### PR TITLE
Add Dicolink word of the day for August 12, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-12.json
+++ b/data/dicolink_word_of_the_day_2026-08-12.json
@@ -1,0 +1,21 @@
+{
+    "word_of_the_day": "Hamadryade",
+    "date": "August 12, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Nymphe des bois, qui naissait avec un arbre et mourait avec lui.",
+                "n.f. Autre nom du cobra royal d'Asie."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Mythologie) Nymphe des bois qui naissait et mourait avec l’arbre dont la garde lui était confiée, et qui ne pouvait jamais le quitter.",
+                "n.  Variante de hamadryas."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 12, 2026**.