### PR TITLE
Add Dicolink word of the day for August 13, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-13.json
+++ b/data/dicolink_word_of_the_day_2026-08-13.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Fifrelin",
+    "date": "August 13, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Familier et vieux. Chose sans valeur, petite monnaie : Ça ne vaut pas un fifrelin."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Chose de peu de valeur, en particulier menue monnaie. ? voir liard, sou, tripette dans l’expression ça ne vaut pas tripette ou clou dans l’expression ça ne vaut pas un clou."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Argot militaire) (1840 ou avant)  Soldat d’infanterie de (la) ligne."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 13, 2026**.