### PR TITLE
Add Dicolink word of the day for August 14, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-14.json
+++ b/data/dicolink_word_of_the_day_2026-08-14.json
@@ -1,0 +1,38 @@
+{
+    "word_of_the_day": "Bacchanale",
+    "date": "August 14, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Littéraire. Débauche bruyante ; orgie."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Par analogie) Représentation d’une danse de bacchantes et de satyres.",
+                "n.  (Par extension) Danse bruyante et tumultueuse, dans un ballet, dans un grand opéra.",
+                "n.  (Familier) Fête bruyante et débridée, associée à danse, déguisement, excès de boisson ou/et de nourriture etc.",
+                "n.  Débauche faite avec grand bruit, orgie."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1: Danse bruyante et tumultueuse. Familièrement, débauche faite avec bruit.",
+                "Sens 2:  Au plur.:  Fêtes que les anciens célébraient en l'honneur de Bacchus. Au sing.:  Représentation d'une danse de bacchantes et de satyres. La bacchanale du Poussin."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Par analogie) Représentation d’une danse de bacchantes et de satyres.",
+                "(Par extension) Danse bruyante et tumultueuse, dans un ballet, dans un grand opéra.",
+                "(Familier) Fête bruyante et débridée, associée à danse, déguisement, excès de boisson ou/et de nourriture, etc.",
+                "Débauche faite avec grand bruit, orgie."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 14, 2026**.