### PR TITLE
Add Dicolink word of the day for August 15, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-15.json
+++ b/data/dicolink_word_of_the_day_2026-08-15.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Sornette",
+    "date": "August 15, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Discours, propos frivole : Débiter des sornettes."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Propos frivole, bagatelle."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Propos frivole, bagatelle."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 15, 2026**.