### PR TITLE
Add Dicolink word of the day for August 16, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-16.json
+++ b/data/dicolink_word_of_the_day_2026-08-16.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Immarcescible",
+    "date": "August 16, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Littéraire. Qui ne peut se flétrir : Gloire immarcescible."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Littéraire) Qui ne peut se flétrir, au propre et au figuré."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 16, 2026**.