### PR TITLE
Add Dicolink word of the day for August 17, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-17.json
+++ b/data/dicolink_word_of_the_day_2026-08-17.json
@@ -1,0 +1,21 @@
+{
+    "word_of_the_day": "Prolégomènes",
+    "date": "August 17, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m.p. Longue introduction présentant les notions nécessaires à la compréhension de l'ouvrage.",
+                "n.m.p. Ensemble des notions préliminaires à une science : Prolégomènes à la linguistique."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Didactique) Longue et ample préface qu’on met à la tête d’un livre, pour donner les notions nécessaires à l’intelligence des matières qui y sont traitées.",
+                "n.  Exposé des principes dont on ne peut dorénavant faire abstraction en abordant l’étude de telle ou telle science."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 17, 2026**.