### PR TITLE
Add Dicolink word of the day for August 18, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-18.json
+++ b/data/dicolink_word_of_the_day_2026-08-18.json
@@ -1,0 +1,33 @@
+{
+    "word_of_the_day": "Sophisme",
+    "date": "August 18, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Argument qui, partant de prémisses vraies, ou jugées telles, aboutit à une conclusion absurde et difficile à réfuter.",
+                "n.m. Raisonnement vicié à la base reposant sur un jeu de mots, un argument séduisant mais faux, destiné à induire l'interlocuteur en erreur."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Raisonnement qui n’est logique ou vrai qu’en apparence, mais qui est délibérément conçu pour tromper ou faire illusion."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Faux raisonnement qui a quelque apparence de vérité.      Par extension. Sophismes d'amour-propre, d'intérêt, de passions, faux raisonnements que suggèrent l'amour-propre, l'intérêt, les passions.  Fig. Les sophismes du cœur, illusions, égarements du cœur."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Rhétorique) Raisonnement qui n’est logique ou vrai qu’en apparence, mais qui est délibérément conçu pour tromper ou faire illusion.",
+                "(Courant) Tout raisonnement logique ou vrai qu’en apparence, qu'il soit exprimé avec bonne foi (paralogisme) ou dans le but de tromper (vrai sophisme)."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 18, 2026**.