### PR TITLE
Add Dicolink word of the day for August 19, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-19.json
+++ b/data/dicolink_word_of_the_day_2026-08-19.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Impréparation",
+    "date": "August 19, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Manque de préparation."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Manque de préparation."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Manque de préparation."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 19, 2026**.