### PR TITLE
Add Dicolink word of the day for August 20, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-20.json
+++ b/data/dicolink_word_of_the_day_2026-08-20.json
@@ -1,0 +1,27 @@
+{
+    "word_of_the_day": "Nervin",
+    "date": "August 20, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "(Pharmacologie) (Vieilli) Qualifiait les substances qui agissent sur le système nerveux central.",
+                "n.  (Pharmacologie) (Vieilli) Quelqu’une de ces substances mêmes à usage thérapeutique."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Terme de médecine. Qui s'emploie à l'intérieur pour fortifier les nerfs ou pour faire disparaître les douleurs dont ils sont le siége. Baume nervin. Substantivement.:  Les nervins."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Pharmacie) (Vieilli) Qualifiait les substances qui agissent sur le système nerveux central.",
+                "(Pharmacie) (Vieilli) Quelqu’une de ces substances mêmes à usage thérapeutique."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 20, 2026**.