### PR TITLE
Add Dicolink word of the day for August 21, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-21.json
+++ b/data/dicolink_word_of_the_day_2026-08-21.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Antipathie",
+    "date": "August 21, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Aversion instinctive, non raisonnée, à l'égard de quelqu'un, de quelque chose ; hostilité."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Aversion, répugnance naturelle et non raisonnée pour quelqu’un, pour quelque chose."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Aversion, répugnance naturelle et non raisonnée pour quelqu’un, pour quelque chose."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 21, 2026**.