### PR TITLE
Add Dicolink word of the day for August 22, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-22.json
+++ b/data/dicolink_word_of_the_day_2026-08-22.json
@@ -1,0 +1,36 @@
+{
+    "word_of_the_day": "Oindre",
+    "date": "August 22, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. tr. Littéraire. Frotter, enduire d'huile ou d'une autre matière grasse : On oignait les athlètes pour la lutte.",
+                "v. tr. Faire une onction sacramentale."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  (Vieilli) Frotter d’huile ou de quelque matière grasse.",
+                "v.  (Religion) Consacrer avec les huiles saintes."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "v. tr. Sens 1: Frotter d'huile ou de quelque matière grasse. Les anciens se faisaient oindre au sortir du bain.  Il se dit aussi de toute autre substance comparée à une huile.",
+                "v. tr. Sens 2: Consacrer avec les huiles saintes. On oint les évêques à leur sacre. On oignait les rois de France avec l'huile de la sainte ampoule.",
+                "v. tr. Sens 3: S'oindre, v. réfl.:  Se frotter avec une substance grasse.  PROVERBEOignez vilain, il vous poindra ; poignez vilain, il vous oindra, se dit pour signifier : caressez un homme de néant, il vous fera du mal ; faites-lui du mal, il vous caressera."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Vieilli) Frotter d’huile ou de quelque matière grasse.",
+                "(Religion) Consacrer avec les huiles saintes."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 22, 2026**.