### PR TITLE
Add Dicolink word of the day for August 24, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-24.json
+++ b/data/dicolink_word_of_the_day_2026-08-24.json
@@ -1,0 +1,35 @@
+{
+    "word_of_the_day": "Timoré",
+    "date": "August 24, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj.n. Qui est d'une prudence excessive."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui est trop disposé à la crainte, au scrupule.",
+                "n.  Celui qui est trop disposé à la crainte, au scrupule."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "adj. Sens 1: Qui est pénétré d'une crainte salutaire, en parlant de la crainte d'offenser Dieu.   Conscience timorée, celle que la crainte du mal alarme facilement, qui porte la délicatesse jusqu'au scrupule.",
+                "adj. Sens 2: Qui porte très loin le scrupule en général."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "Qui est trop disposé à la crainte, au scrupule.",
+                "Qui a peur dans une situation particulière.",
+                "Celui qui est trop disposé à la crainte, au scrupule."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 24, 2026**.