### PR TITLE
Add Dicolink word of the day for August 25, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-25.json
+++ b/data/dicolink_word_of_the_day_2026-08-25.json
@@ -1,0 +1,25 @@
+{
+    "word_of_the_day": "Alexithymie",
+    "date": "August 25, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.f. Déficit de verbalisation des émotions."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  (Psychologie) Incapacité à mettre des mots sur des sentiments."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "(Psychologie) Incapacité à mettre des mots sur des sentiments."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 25, 2026**.