### PR TITLE
Add Dicolink word of the day for August 26, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-26.json
+++ b/data/dicolink_word_of_the_day_2026-08-26.json
@@ -1,0 +1,30 @@
+{
+    "word_of_the_day": "Panégyrique",
+    "date": "August 26, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "n.m. Éloge fait en public ou par écrit de quelqu'un, d'une institution, d'un pays, etc. : Prononcer un panégyrique.",
+                "n.m. Éloge le plus souvent excessif : Faire le panégyrique d'un collaborateur."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "n.  Discours public fait à la louange de quelqu’un ou de quelque chose, éloge."
+            ]
+        },
+        {
+            "source": "Le littré",
+            "definitions": [
+                "Sens 1: Discours public à la louange de quelqu'un. Le Panégyrique de Trajan par Pline le jeune.         Adjectivement: . Discours panégyrique.",
+                "Sens 2:  Par extension, toute parole d'éloge.",
+                "Sens 3:  Ironiquement, discours médisant, malin. Il vous aura bien de l'obligation, vous lui faites là un beau panégyrique.",
+                "Sens 4: Livre ecclésiastique à l'usage des Grecs ; il contient des éloges des saints.",
+                "Sens 5:  Adj.:  Terme d'antiquité. Où il y a un grand concours de monde. Assemblées, fêtes, jeux panégyriques."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 26, 2026**.