### PR TITLE
Add Dicolink word of the day for August 27, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-27.json
+++ b/data/dicolink_word_of_the_day_2026-08-27.json
@@ -1,0 +1,28 @@
+{
+    "word_of_the_day": "Mordoré",
+    "date": "August 27, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui est d'un brun chaud, à reflets dorés : Souliers mordorés."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "De couleur brun chaud avec des reflets dorés. #87591A",
+                "n.  Couleur brun chaud avec des reflets dorés. #87591A"
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "De couleur brun chaud avec des reflets dorés.  #87591A",
+                "Couleur brun chaud avec des reflets dorés.  #87591A",
+                "Participe passé masculin singulier du verbe mordorer."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 27, 2026**.