### PR TITLE
Add Dicolink word of the day for August 28, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-28.json
+++ b/data/dicolink_word_of_the_day_2026-08-28.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Imputrescible",
+    "date": "August 28, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Qui ne peut se putréfier : Bois imputrescible."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui ne peut pas se putréfier, se corrompre ou pourrir."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 28, 2026**.