### PR TITLE
Add Dicolink word of the day for August 29, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-29.json
+++ b/data/dicolink_word_of_the_day_2026-08-29.json
@@ -1,0 +1,29 @@
+{
+    "word_of_the_day": "Balbutier",
+    "date": "August 29, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "v. intr. Parler avec hésitation, difficulté : L'émotion le fait balbutier.",
+                "v. intr. En parlant de quelque chose, n'en être qu'à ses débuts : Science qui balbutie.",
+                "v. tr. Dire, prononcer quelque chose avec hésitation et confusément : Il balbutia qu'il s'était trompé."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "v.  S’exprimer ou prononcer difficilement, en ânonnant, en hésitant.",
+                "v.  (Figuré) Agir difficilement."
+            ]
+        },
+        {
+            "source": "Wiktionnaire",
+            "definitions": [
+                "S’exprimer ou prononcer difficilement, en ânonnant, en hésitant.",
+                "(Figuré) Agir difficilement."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 29, 2026**.