### PR TITLE
Add Dicolink word of the day for August 30, 2026

### DIFF
--- a/data/dicolink_word_of_the_day_2026-08-30.json
+++ b/data/dicolink_word_of_the_day_2026-08-30.json
@@ -1,0 +1,19 @@
+{
+    "word_of_the_day": "Vulnérant",
+    "date": "August 30, 2026",
+    "source_url": "https://www.dicolink.com/motdujour",
+    "definitions": [
+        {
+            "source": "Grand Dictionnaire de la langue française numérisé",
+            "definitions": [
+                "adj. Se dit d'un organe animal ou végétal, d'un projectile, etc., susceptible de provoquer des blessures."
+            ]
+        },
+        {
+            "source": "Portail internet \"Le Dictionnaire\"",
+            "definitions": [
+                "Qui blesse."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Automatically added the Dicolink word of the day for **August 30, 2026**.